### PR TITLE
Fix boost gcc cpp11

### DIFF
--- a/scripts/install_boost.sh
+++ b/scripts/install_boost.sh
@@ -13,8 +13,7 @@ then
   then
     ln -s $BOOSTVERSION boost
   fi
-fi 
-
+fi
 
 
 if [ "$check" = "1" ];
@@ -25,60 +24,65 @@ then
   if (not_there Boost $checkfile);
   then
     cd $SIMPATH/basics/boost
-	
+
     cxxflags=""
     if [ $hascxx11 ];
     then
        cxxflags="$cxxflags -std=c++11"
-    fi   
+    fi
 
     if [ $haslibcxx ];
     then
        cxxflags="$cxxflags -stdlib=libc++"
-    fi   
-
-	if [ "$compiler" = "intel" ];
-	then
-            ./bootstrap.sh --with-toolset=intel-linux
-           ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=intel --prefix=$install_prefix  --layout=system -j $number_of_processes install
-	elif [ "$compiler" = "PGI" ];
-	then
-            ./bootstrap.sh --with-toolset=pgi
-           ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=pgi --prefix=$install_prefix --layout=system -j $number_of_processes install
-	elif [ "$compiler" = "Clang" ];
-	then
-            ./bootstrap.sh --with-toolset=clang
-           if [ $hascxx11 ];
-           then
-             ./b2 cxxflags="$cxxflags" linkflags="$cxxflags" --build-dir=$PWD/tmp --build-type=minimal --toolset=clang --prefix=$install_prefix --layout=system -j $number_of_processes install
-           else
-             ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=clang --prefix=$install_prefix --layout=system -j $number_of_processes install
-           fi
-	elif [ "$arch" = "macosx64" ];
-        then
-            ./bootstrap.sh --with-toolset=darwin
-           ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=darwin --prefix=$install_prefix --layout=system -j $number_of_processes install
-	elif [ "$arch" = "macosx" ];
-        then
-            ./bootstrap.sh --with-toolset=darwin
-           ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=darwin --prefix=$install_prefix --layout=system -j $number_of_processes install
-	else
-            ./bootstrap.sh --with-toolset=gcc
-           ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=gcc --prefix=$install_prefix  --layout=system -j $number_of_processes install
-	fi
-	
-        if [ "$platform" = "macosx" ];
-        then
-            cd  $install_prefix/lib
-	    create_links dylib so
-	fi
-
-	check_all_libraries $install_prefix/lib
-
-	check_success Boost $checkfile
-	check=$?
-		
     fi
+
+  if [ "$compiler" = "intel" ];
+  then
+    ./bootstrap.sh --with-toolset=intel-linux
+    ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=intel --prefix=$install_prefix  --layout=system -j $number_of_processes install
+  elif [ "$compiler" = "PGI" ];
+  then
+    ./bootstrap.sh --with-toolset=pgi
+    ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=pgi --prefix=$install_prefix --layout=system -j $number_of_processes install
+  elif [ "$compiler" = "Clang" ];
+  then
+    ./bootstrap.sh --with-toolset=clang
+    if [ $hascxx11 ];
+    then
+      ./b2 cxxflags="$cxxflags" linkflags="$cxxflags" --build-dir=$PWD/tmp --build-type=minimal --toolset=clang --prefix=$install_prefix --layout=system -j $number_of_processes install
+    else
+      ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=clang --prefix=$install_prefix --layout=system -j $number_of_processes install
+    fi
+  elif [ "$arch" = "macosx64" ];
+  then
+    ./bootstrap.sh --with-toolset=darwin
+    ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=darwin --prefix=$install_prefix --layout=system -j $number_of_processes install
+  elif [ "$arch" = "macosx" ];
+  then
+    ./bootstrap.sh --with-toolset=darwin
+    ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=darwin --prefix=$install_prefix --layout=system -j $number_of_processes install
+  else
+    ./bootstrap.sh --with-toolset=gcc
+    if [ $hascxx11 ];
+    then
+      ./b2 cxxflags="$cxxflags" linkflags="$cxxflags" --build-dir=$PWD/tmp --build-type=minimal --toolset=gcc --prefix=$install_prefix --layout=system -j $number_of_processes install
+    else
+      ./b2 --build-dir=$PWD/tmp --build-type=minimal --toolset=gcc --prefix=$install_prefix  --layout=system -j $number_of_processes install
+    fi
+  fi
+
+  if [ "$platform" = "macosx" ];
+  then
+    cd  $install_prefix/lib
+    create_links dylib so
+  fi
+
+  check_all_libraries $install_prefix/lib
+
+  check_success Boost $checkfile
+  check=$?
+
+  fi
 fi
 
 cd $SIMPATH


### PR DESCRIPTION
These changes allowed me to compile FairSoft on Ubuntu 14.04 and GCC 4.8.2 with C++11 enabled. Without these, not all boost libraries were properly created, which disabled compilation of FairMQ in FairRoot.
Please see if this is OK :)

Bonus: style fix :D
