### PR TITLE
Added option to run configure.sh with a parameter file.

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -139,6 +139,16 @@ then
   build_python=no
   export SIMPATH_INSTALL=$PWD/installation
   onlyreco=1
+elif [ "$installation_type" = "params.conf" ]
+then
+  if [ -e "params.conf" ]
+  then
+    source params.conf
+  else
+    echo "The parameter file params.conf does not exist."
+    echo "Please create it, e.g. as an extraction from configure.sh."
+    exit 42
+  fi
 else
   echo "Parameter given to the script is not known."
   echo "Call the script either with no parameter, then your are guided through the installation procedure,"
@@ -148,6 +158,7 @@ else
   echo " - custom"
   echo " - grid"
   echo " - onlyreco"
+  echo " - params.conf"
   exit 42
 fi
 

--- a/params.conf
+++ b/params.conf
@@ -1,0 +1,8 @@
+compiler=gcc
+debug=yes
+optimize=no
+geant4_download_install_data_automatic=yes
+geant4_install_data_from_dir=no
+build_python=no
+export SIMPATH_INSTALL=$PWD/installation
+onlyreco=0


### PR DESCRIPTION
params.conf holds all the variable definitions which are usually defined in configure.sh itself. When 'params.conf' is given as an argument to configure.sh, it now extracts all the installation variables from the file. Benefits: Create your own (personal) configure file to keep all values across different FairSoft versions; run configure.sh in a more 'scripted' way, e.g. for your experiment's default setup.

Example params.conf given, but not necessarily needed in FairSoft repo.
