### PR TITLE
adjusting AliRoot version 

### DIFF
--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -100,5 +100,5 @@ export DDS_LOCATION="https://github.com/FairRootGroup/DDS.git"
 export DDSVERSION=master
 
 export ALIROOT_LOCATION="http://git.cern.ch/pub/AliRoot"
-export ALIROOTVERSION=splitdev
+export ALIROOTVERSION=feature-splitdev
 


### PR DESCRIPTION
AliRoot branch name has been renamed from 'splitdev' to 'feature-splitdev'
