### PR TITLE
Do not build Pluto with Root 6

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -105,6 +105,15 @@ then
    export Fortran_Needed=FALSE
 fi
 
+if [ "$build_root6" = "yes" ]
+then
+  pluto=0
+elif [ "$build_root6" = "no" ]
+then
+  pluto=0
+fi
+
+
 if [ "$installation_type" = "grid" ];
 then
   export BUILD_BATCH=TRUE
@@ -274,9 +283,9 @@ fi
 
 ##################### Pluto #############################################
 
-if [ "$check" = "1" -a "$onlyreco" = "0" ];
+if [ "$check" = "1" -a "$onlyreco" = "0" -a "$pluto" = "1" ];
 then
-  source scripts/install_pluto.sh
+     source scripts/install_pluto.sh
 fi
 
 ##################### Geant 3 VMC #############################################

--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -38,7 +38,7 @@ export GEANT4VERSIONp=Geant4-10.1.0
 export ROOT_LOCATION="http://root.cern.ch/git/root.git"
 if [ "$build_root6" = "yes" ]; then
   # Root v6.02.01
-  export ROOTVERSION=v6-02-01
+  export ROOTVERSION=v6-03-04
 else
   # Root v5.34.26
   export ROOTVERSION=v5-34-26


### PR DESCRIPTION
Pluto does not compile with the current ROOT 6 due to changes in the TF1 class in root
Pluto will be build with ROOT5 but not with ROOT6