### PR TITLE
Geant4_VMC with Garfield example.

### DIFF
--- a/scripts/install_geant4_vmc.sh
+++ b/scripts/install_geant4_vmc.sh
@@ -26,13 +26,18 @@ then
     fi
   fi
 
+  if [ ! -z $GARFIELD_HOME ]; then
+    GARFIELD="-DGarfield_DIR=$GARFIELD_HOME"
+  fi
+
   mkdir build
   cd build
   cmake .. -DCMAKE_INSTALL_PREFIX=$SIMPATH_INSTALL -DGeant4VMC_USE_VGM=ON \
   	-DGeant4VMC_USE_GEANT4_UI=Off -DGeant4VMC_USE_GEANT4_VIS=Off \
   	-DGeant4VMC_USE_GEANT4_G3TOG4=On -DGeant4_DIR=$SIMPATH_INSTALL \
   	-DROOT_DIR=$SIMPATH_INSTALL -DVGM_DIR=$SIMPATH_INSTALL/lib/$VGMDIR \
-        -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
+        -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC \
+    $GARFIELD
 
   make install -j$number_of_processes
 

--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -57,7 +57,7 @@ export VGMVERSION=v4-3
 export VGMDIR=VGM-4.3.0
 
 export GEANT4VMC_LOCATION="http://root.cern.ch/git/geant4_vmc.git"
-export GEANT4VMCBRANCH=v3-2
+export GEANT4VMCBRANCH=v3-3
 
 export MILLEPEDE_LOCATION="http://svnsrv.desy.de/public/MillepedeII/tags/"
 export MILLEPEDE_VERSION=V04-03-01


### PR DESCRIPTION
Use geant4_vmc version 3.3. Configure to look for Garfield installation.