### PR TITLE
New CMake required for Root6

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ directory of FairSoft.
 
 ##Included Packages
 
-* cmake 3.3.2 (only installed if installed version is to old)
+* cmake 3.7.2 (only installed if installed version is too old)
 * gtest  1.7.0
 * gsl 1.16
 * icu4c 53.1

--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-export CMAKE_LOCATION="http://www.cmake.org/files/v3.3/"
-export CMAKEVERSION_REQUIRED=cmake-3.3.0
-export CMAKEVERSION=cmake-3.3.2
+export CMAKE_LOCATION="http://www.cmake.org/files/v3.7/"
+export CMAKEVERSION_REQUIRED=cmake-3.4.3
+export CMAKEVERSION=cmake-3.7.2
 
 export GTEST_LOCATION="https://github.com/google/googletest/archive/"
 export GTESTVERSION=release-1.7.0


### PR DESCRIPTION
On a system with outdated cmake, installing root6 fails with 
```
CMake Error at CMakeLists.txt:2 (cmake_minimum_required):
  CMake 3.4.3 or higher is required.  You are running version 3.3.2
```
The cmake version installed by FairSoft is too old as well. Require 3.4.3 and install 3.7.2.