### PR TITLE
Fix missing setting for mqonly=0

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -97,6 +97,8 @@ fi
 if [ "$build_MQOnly" = "yes" ]
 then
     mqonly=1
+else
+    mqonly=0
 fi
 
 if [ "$install_sim" = "yes" ]


### PR DESCRIPTION
When `build_MQOnly` is `"no"`, `mqonly` is not set to `0`, which then skips building ROOT. This fixes it.