### PR TITLE
Built with builtin libcurl

### DIFF
--- a/scripts/install_cmake.sh
+++ b/scripts/install_cmake.sh
@@ -75,7 +75,7 @@ then
   then
     cd $SIMPATH/basics/cmake
     ./bootstrap --prefix=$install_prefix --docdir=/share/doc/CMake --mandir=/share/man \
-                --no-system-libs --system-curl --parallel=$number_of_processes
+                --no-system-libs --parallel=$number_of_processes
     $MAKE_command install -j $number_of_processes
     check_success CMake $checkfile
 

--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -117,7 +117,7 @@ export FAIRROOT_LOCATION="https://github.com/FairRootGroup/FairRoot.git"
 export FAIRROOTVERSION=dev
 
 export DDS_LOCATION="https://github.com/FairRootGroup/DDS.git"
-export DDSVERSION=181b66a
+export DDSVERSION=2.1-1-g181b66a
 
 export ALIROOT_LOCATION="http://git.cern.ch/pub/AliRoot"
 export ALIROOTVERSION=master


### PR DESCRIPTION
The way the system libcurl is used prohibits the correct
evaluation of the NO_PROXY environment variable.

---

As a reminder for the details see the following discussion: https://gitlab.kitware.com/cmake/cmake/merge_requests/1409