### PR TITLE
Bump FairMQ to 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ directory of FairSoft.
 | FlatBuffers |1.9.0|
 | MessagePack |2.1.5|
 | DDS |2.0|
-| FairMQ |1.2.1|
+| FairMQ |1.2.3|
 | FairLogger |1.2.0|
 
 In case the python bindings are build the following additional packages will be installed

--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -132,4 +132,4 @@ export FAIRLOGGER_LOCATION="https://github.com/FairRootGroup/FairLogger"
 export FAIRLOGGER_VERSION=v1.2.0
 
 export FAIRMQ_LOCATION="https://github.com/FairRootGroup/FairMQ"
-export FAIRMQ_VERSION=v1.2.1
+export FAIRMQ_VERSION=v1.2.3


### PR DESCRIPTION
Contains a bugfix for the bug discovered by @karabowi earlier today. Also contains the compilation speed improvements by @rbx.