### PR TITLE
Bump msgpack, nanomsg and FairMQ

### DIFF
--- a/make_clean.sh
+++ b/make_clean.sh
@@ -519,37 +519,6 @@ clean_protobuf() {
   fi
 }
 
-
-clean_nanomsg() {
-  echo "Remove temporary files from package nanomsg"
-  if [ -e $SIMPATH/basics/nanomsg ]; then
-    cd $SIMPATH/basics/nanomsg
-    make clean
-  fi
-
-  if [ "$rm_installed_files" = "true" ]; then
-    echo "Remove installed files from package nanomsg"
-    if [ -e $SIMPATH_INSTALL/bin/nanocat ]; then
-      cd $SIMPATH/basics/nanomsg
-      make uninstall
-      rm -f $SIMPATH_INSTALL/bin/nn_*
-    fi
-  fi
-}
-
-
-clean_msgpack (){
-echo "Remove temporary files from package Msgpack"
-if [ -e $SIMPATH/basics/msgpack/build ]; then
-  cd $SIMPATH/basics/msgpack/build
-  make clean
-fi
-
-if [ "$rm_installed_files" = "true" ]; then
-  echo "Remove installed files from package Msgpack"
-  rm -f $SIMPATH_INSTALL/lib/libmsgpackc.*
-fi
-}
 clean_fairlogger() {
   echo "Remove temporary files from package fairlogger"
   if [ -e $SIMPATH/basics/FairLogger ]; then
@@ -622,8 +591,43 @@ clean_asiofi() {
 
 }
 
+clean_msgpack() {
+  echo "Remove temporary files from package msgpack"
+  if [ -e $SIMPATH/basics/msgpack ]; then
+    rm -rf $SIMPATH/basics/msgpack
+  fi
+  if [ "$rm_installed_files" = "true" ]; then
+    echo "Remove installed files from package msgpack"
+    if [ -e $SIMPATH_INSTALL/include/msgpack.hpp ]; then
+      rm -rf $SIMPATH_INSTALL/include/msgpack*
+      rm -rf $SIMPATH_INSTALL/lib/cmake/msgpack*
+      rm -rf $SIMPATH_INSTALL/lib/libmsgpackc*
+    fi
+  fi
+}
+
+clean_nanomsg() {
+  echo "Remove temporary files from package nanomsg"
+  if [ -e $SIMPATH/basics/nanomsg ]; then
+    rm -rf $SIMPATH/basics/nanomsg
+  fi
+
+  if [ "$rm_installed_files" = "true" ]; then
+    echo "Remove installed files from package nanomsg"
+    if [ -e $SIMPATH_INSTALL/bin/nanocat ]; then
+      rm -f $SIMPATH_INSTALL/bin/nanocat
+      rm -rf $SIMPATH_INSTALL/bin/nn_*
+      rm -rf $SIMPATH_INSTALL/include/nanomsg*
+      rm -rf $SIMPATH_INSTALL/lib/cmake/nanomsg*
+      rm -rf $SIMPATH_INSTALL/lib/pkgconfig/nanomsg*
+      rm -rf $SIMPATH_INSTALL/lib/libnanomsg*
+    fi
+  fi
+}
+
+
 clean_all() {
-  valid_packages="cmake gtest gsl icu boost pythia6 hepmc pythia8 xercesc mesa geant4 xrootd root g4py pluto geant3 vgm geant4_vmc millipede zeromq protobuf nanomsg fairlogger DDS fairmq asiofi"
+  valid_packages="cmake gtest gsl icu boost pythia6 hepmc pythia8 xercesc mesa geant4 xrootd root g4py pluto geant3 vgm geant4_vmc millipede zeromq protobuf nanomsg fairlogger DDS fairmq asiofi msgpack"
 
   for pack in $valid_packages
   do
@@ -632,7 +636,7 @@ clean_all() {
 }
 
 check_package_exist() {
-  valid_packages="cmake gtest gsl icu boost pythia6 hepmc pythia8 xercesc mesa geant4 xrootd root g4py pluto geant3 vgm geant4_vmc millipede zeromq protobuf nanomsg fairlogger DDS fairmq asiofi"
+  valid_packages="cmake gtest gsl icu boost pythia6 hepmc pythia8 xercesc mesa geant4 xrootd root g4py pluto geant3 vgm geant4_vmc millipede zeromq protobuf nanomsg fairlogger DDS fairmq asiofi msgpack"
 
   if [ "$1" = "all" ]; then
     return

--- a/scripts/install_msgpack.sh
+++ b/scripts/install_msgpack.sh
@@ -1,42 +1,35 @@
 #!/bin/bash
 
+cd $SIMPATH/basics
+
 if [ ! -d  $SIMPATH/basics/msgpack ];
 then
-  cd $SIMPATH/basics
-  echo "*** Downloading MessagePack sources ***"
   git clone $MSGPACK_LOCATION msgpack
-  cd $SIMPATH/basics/msgpack
-  git checkout -b $MSGPACK_BRANCH $MSGPACK_BRANCH
 fi
 
-install_prefix=$SIMPATH_INSTALL
-checkfile=$install_prefix/lib/libmsgpackc.a
+checkfile=$SIMPATH_INSTALL/include/msgpack.hpp
 
-if (not_there MessagePack $checkfile);
+if (not_there msgpack $checkfile);
 then
-    cd $SIMPATH/basics/msgpack
-
-    mkdir -p build
-    cd build
-
-    cmake -DCMAKE_INSTALL_PREFIX=$install_prefix \
-          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-          -DCMAKE_CXX_COMPILER=$CXX \
-          -DCMAKE_C_COMPILER=$CC \
-          -DMSGPACK_CXX11=ON \
-          -DMSGPACK_BUILD_TESTS=OFF \
-          ..
-
-    make -j$number_of_processes
-
-    make install
-
-    check_all_libraries  $install_prefix/lib
-
-    check_success MessagePack $checkfile
-    check=$?
+  cd msgpack
+  git checkout $MSGPACK_VERSION
+  if [ ! -d  build ];
+  then
+    mkdir build
+  fi
+  cd build
+  cmake -DCMAKE_INSTALL_PREFIX=$SIMPATH_INSTALL \
+        -DCMAKE_PREFIX_PATH=$SIMPATH_INSTALL \
+        -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+        -DCMAKE_CXX_COMPILER=$CXX \
+        -DCMAKE_C_COMPILER=$CC \
+        -DMSGPACK_CXX11=ON \
+        -DMSGPACK_BUILD_TESTS=OFF \
+        ..
+  cmake --build . --target install -- -j$number_of_processes
 fi
+check_success msgpack $checkfile
+check=$?
 
 cd $SIMPATH
-
 return 1

--- a/scripts/install_nanomsg.sh
+++ b/scripts/install_nanomsg.sh
@@ -1,50 +1,31 @@
 #!/bin/bash
 
+cd $SIMPATH/basics
 
 if [ ! -d  $SIMPATH/basics/nanomsg ];
 then
-  cd $SIMPATH/basics
-  if [ ! -e $NANOMSG_VERSION.tar.gz ];
-  then
-    echo "*** Downloading nanomsg sources ***"
-    download_file $NANOMSG_LOCATION/$NANOMSG_VERSION.tar.gz
-  fi
-  untar nanomsg $NANOMSG_VERSION.tar.gz
-  if [ -d $NANOMSG_VERSION ];
-  then
-    ln -s $NANOMSG_VERSION nanomsg
-  fi
+  git clone $NANOMSG_LOCATION nanomsg
 fi
 
-install_prefix=$SIMPATH_INSTALL
-
-checkfile=$install_prefix/bin/nanocat
+checkfile=$SIMPATH_INSTALL/bin/nanocat
 
 if (not_there nanomsg $checkfile);
 then
-    cd $SIMPATH/basics/nanomsg-$NANOMSG_VERSION
-
-    # is this still relevant for the cmake version?
-    if [ "$arch" == "ppc64le" ];then
-       autoreconf -i -f -v
-    fi
-
+  cd nanomsg
+  git checkout $NANOMSG_VERSION
+  if [ ! -d  build ];
+  then
     mkdir build
-    cd build
-    cmake -DCMAKE_INSTALL_PREFIX=$install_prefix -DNN_ENABLE_DOC=OFF ..
-    cmake --build . --target install
-
-    ## old versions (pre cmake):
-    # ./configure --prefix=$install_prefix
-    # make -j$number_of_processes
-    # make install
-
-    check_all_libraries  $install_prefix/lib
-
-    check_success nanomsg $checkfile
-    check=$?
+  fi
+  cd build
+  cmake -DCMAKE_INSTALL_PREFIX=$install_prefix \
+        -DCMAKE_PREFIX_PATH=$SIMPATH_INSTALL \
+        -DNN_ENABLE_DOC=OFF \
+        ..
+  cmake --build . --target install -- -j$number_of_processes
 fi
+check_success nanomsg $checkfile
+check=$?
 
 cd $SIMPATH
-
 return 1

--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -78,13 +78,11 @@ export PROTOBUF_VERSION=3.4.0
 export FLATBUFFERS_LOCATION="https://github.com/FairRootGroup/flatbuffers.git"
 export FLATBUFFERS_BRANCH=v1.9.0-fairroot
 
-export MSGPACK_LOCATION="https://github.com/FairRootGroup/msgpack-c.git"
-export MSGPACK_BRANCH=cpp-2.1.5-fairroot
+export MSGPACK_LOCATION="https://github.com/msgpack/msgpack-c"
+export MSGPACK_VERSION=cpp-3.1.0
 
-export NANOMSG_LOCATION="https://github.com/nanomsg/nanomsg/archive/"
-#export NANOMSG_LOCATION="http://download.nanomsg.org/"
-export NANOMSG_VERSION=1.0.0
-
+export NANOMSG_LOCATION="https://github.com/nanomsg/nanomsg"
+export NANOMSG_VERSION=1.1.4
 
 export G4TENDL_VERSION=G4TENDL1.3.2
 export G4TENDL_TAR=G4TENDL1.3.2.tar.gz
@@ -132,7 +130,7 @@ export FAIRLOGGER_LOCATION="https://github.com/FairRootGroup/FairLogger"
 export FAIRLOGGER_VERSION=v1.2.0
 
 export FAIRMQ_LOCATION="https://github.com/FairRootGroup/FairMQ"
-export FAIRMQ_VERSION=v1.2.3
+export FAIRMQ_VERSION=v1.2.7
 
 export OFI_LOCATION="https://github.com/ofiwg/libfabric"
 export OFI_TESTS_LOCATION="https://github.com/ofiwg/fabtests"


### PR DESCRIPTION
msgpack -> 3.1.0
nanomsg -> 1.1.4
FairMQ -> 1.2.7

This is needed to update CI environments for most recent FairMQ development (FairRootGroup/FairMQ#76).