### PR TITLE
Fix Geant3 with newer gfortran versions

### DIFF
--- a/scripts/install_geant3.sh
+++ b/scripts/install_geant3.sh
@@ -21,6 +21,8 @@ then
 
   cd $SIMPATH/transport/geant3
 
+  mypatch ../geant3_gfortran.patch | tee -a $logfile
+  
 # ????
 #  if [ "$build_root6" = "yes" ]; then
 #    mypatch ../geant3_root6.patch

--- a/transport/geant3_gfortran.patch
+++ b/transport/geant3_gfortran.patch
@@ -1,0 +1,16 @@
+File Edit Options Buffers Tools Diff Help                                                                                                                                       
+diff --git a/CMakeLists.txt b/CMakeLists.txt                                                                                                                                    
+index fd6eb27..eb8ef1b 100644                                                                                                                                                   
+--- a/CMakeLists.txt                                                                                                                                                            
++++ b/CMakeLists.txt                                                                                                                                                            
+@@ -61,3 +61,10 @@ include(Geant3BuildProject)
+ #--- CPack ----------------- --------------------------------------------------                                                                                                
+ include(Geant3CPack)                                                                                                                                                           
+                                                                                                                                                                                
++#--- Workaround for newer gfortran versions-------------------------------------                                                                                               
++if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")                                                                                                                                   
++  if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 8.1)                                                                                                                       
++    message(STATUS "gfortran 8.1+ requires '-std=legacy' to compile geant3")                                                                                                   
++    SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=legacy")                                                                                                              
++  endif()                                                                                                                                                                      
++endif() #CMAKE_CXX_COMPILER_VERSION                                                                                                                                            


### PR DESCRIPTION
Building Geant3 with gfortran versions > 8.1 will fail with hundreds of errors of type:
`Error: Actual argument contains too few elements for dummy argument ‘X’ (6/50) at (1)`
This is an intentional behaviour change:
> * When an actual argument contains too few elements for a dummy argument, an error is now issued. The -std=legacy option can be  used to still compile such code.
[Source](https://www.gnu.org/software/gcc/gcc-8/changes.html)

This pull request fixes this issue with (hopefully) minimum side effects. This patch series could also be backported to older FairSoft releases.