### PR TITLE
Fix geant4_vmc version in install script

### DIFF
--- a/scripts/install_geant4_vmc.sh
+++ b/scripts/install_geant4_vmc.sh
@@ -54,7 +54,7 @@ then
 
   cd $SIMPATH_INSTALL
   mkdir -p share/geant4_vmc
-  ln -s $SIMPATH_INSTALL/share/Geant4VMC-3.3.0/examples/macro $SIMPATH_INSTALL/share/geant4_vmc/macro
+  ln -s $SIMPATH_INSTALL/share/Geant4VMC-3.6.0/examples/macro $SIMPATH_INSTALL/share/geant4_vmc/macro
 fi
 
 if [ "$platform" = "macosx" ];


### PR DESCRIPTION
Geant4VMC was updated to version 3.6, but the linked directory in this file stayed at v3.3. 
This caused issues with several tests using the geant4libs.C macro, which could no longer be found.