### PR TITLE
Fix Build Issue with geant3 patch

### DIFF
--- a/transport/geant3_gfortran.patch
+++ b/transport/geant3_gfortran.patch
@@ -1,6 +1,3 @@
-File Edit Options Buffers Tools Diff Help                                                                                                                                       
-diff --git a/CMakeLists.txt b/CMakeLists.txt                                                                                                                                    
-index fd6eb27..eb8ef1b 100644                                                                                                                                                   
 --- a/CMakeLists.txt                                                                                                                                                            
 +++ b/CMakeLists.txt                                                                                                                                                            
 @@ -61,3 +61,10 @@ include(Geant3BuildProject)


### PR DESCRIPTION
The patch in Issue #109 contains 3 superfluous lines at the beginning of the file that may cause the build to fail. This patch removes them.