### PR TITLE
enable multi-threaded build for G4

### DIFF
--- a/scripts/install_geant4.sh
+++ b/scripts/install_geant4.sh
@@ -64,6 +64,7 @@ then
   cmake -DCMAKE_INSTALL_PREFIX=$install_prefix \
         -DCMAKE_INSTALL_LIBDIR=$install_prefix/lib \
         -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+        -DGEANT4_BUILD_MULTITHREADED=ON \
         -DCMAKE_CXX_COMPILER=$CXX \
         -DCMAKE_C_COMPILER=$CC \
         -DGEANT4_USE_G3TOG4=ON \


### PR DESCRIPTION
enable multi-threaded build for G4 by default