### PR TITLE
Correct the release version of Geant4

### DIFF
--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -36,7 +36,7 @@ export MESAVERSION=MesaLib-7.10.3
 
 export GEANT4_LOCATION="https://github.com/Geant4/geant4.git/"
 export GEANT4VERSION=geant4-10.5-release
-export GEANT4VERSIONp=Geant4-10.5.0
+export GEANT4VERSIONp=Geant4-10.5.1
 
 export ROOT_LOCATION="https://github.com/root-project/root"
 export ROOTVERSION=v6-16-00


### PR DESCRIPTION
Causes creation of symbolic link pointing to non existing version.