### PR TITLE
Bump FairMQ to v1.4.8

### DIFF
--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -131,7 +131,7 @@ export FAIRLOGGER_LOCATION="https://github.com/FairRootGroup/FairLogger"
 export FAIRLOGGER_VERSION=v1.4.0
 
 export FAIRMQ_LOCATION="https://github.com/FairRootGroup/FairMQ"
-export FAIRMQ_VERSION=v1.4.3
+export FAIRMQ_VERSION=v1.4.8
 
 export OFI_LOCATION="https://github.com/ofiwg/libfabric"
 export OFI_TESTS_LOCATION="https://github.com/ofiwg/fabtests"


### PR DESCRIPTION
v1.4.3 has a bug and did not build against DDS 2.4. This bug was fixed
in v1.4.5, but let us pick up the most recent release here anyways.