### PR TITLE
Move hepmc variant pinning into spack environments

### DIFF
--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -10,6 +10,7 @@ spack:
     - boost@1.68.0
     - fairlogger@1.4.0
     - pythia6@428-alice1
+    - hepmc@2.06.09 length=CM momentum=GEV
     - pythia8@8240
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -10,6 +10,7 @@ spack:
     - boost@1.68.0
     - fairlogger@1.4.0
     - pythia6@428-alice1
+    - hepmc@2.06.09 length=CM momentum=GEV
     - pythia8@8240
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root

--- a/env/jun19/sim_no-threads.yaml
+++ b/env/jun19/sim_no-threads.yaml
@@ -10,6 +10,7 @@ spack:
     - boost@1.68.0
     - fairlogger@1.4.0
     - pythia6@428-alice1
+    - hepmc@2.06.09 length=CM momentum=GEV
     - pythia8@8240
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep~threads
     - $root

--- a/env/jun19/sim_threads.yaml
+++ b/env/jun19/sim_threads.yaml
@@ -10,6 +10,7 @@ spack:
     - boost@1.68.0
     - fairlogger@1.4.0
     - pythia6@428-alice1
+    - hepmc@2.06.09 length=CM momentum=GEV
     - pythia8@8240
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root

--- a/packages/pythia8/package.py
+++ b/packages/pythia8/package.py
@@ -38,8 +38,8 @@ class Pythia8(AutotoolsPackage):
     version('8230', sha256='332fad0ed4f12e6e0cb5755df0ae175329bc16bfaa2ae472d00994ecc99cd78d')
     version('8212', sha256='f8fb4341c7e8a8be3347eb26b00329a388ccf925313cfbdba655a08d7fd5a70e')
 
-    depends_on('hepmc@2.06.09 length=CM momentum=GEV')
     depends_on('rsync', type='build')
+    depends_on('hepmc@2:2.99')
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Talked to @fuhlig1 today:

The pythia8 recipe should only declare the really needed dependencies.

So moved the unit declaration variants into the spack environments.

@kresan @dennisklein : Could you please take care to include this in the 20 release?