### PR TITLE
Root 6.16.00 and Python

### DIFF
--- a/packages/root/cmake_python.patch
+++ b/packages/root/cmake_python.patch
@@ -1,0 +1,34 @@
+--- a/interpreter/llvm/src/CMakeLists.txt
++++ b/interpreter/llvm/src/CMakeLists.txt
+@@ -598,21 +598,7 @@
+
+ include(HandleLLVMOptions)
+
+-# Verify that we can find a Python 2 interpreter.  Python 3 is unsupported.
+-# FIXME: We should support systems with only Python 3, but that requires work
+-# on LLDB.
+-set(Python_ADDITIONAL_VERSIONS 2.7)
+-include(FindPythonInterp)
+-if( NOT PYTHONINTERP_FOUND )
+-  message(FATAL_ERROR
+-"Unable to find Python interpreter, required for builds and testing.
+-
+-Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
+-endif()
+-
+-if( ${PYTHON_VERSION_STRING} VERSION_LESS 2.7 )
+-  message(FATAL_ERROR "Python 2.7 or newer is required")
+-endif()
++find_package(Python2 COMPONENTS Interpreter REQUIRED)
+
+ ######
+ # LLVMBuild Integration
+@@ -644,7 +630,7 @@
+
+ message(STATUS "Constructing LLVMBuild project information")
+ execute_process(
+-  COMMAND ${PYTHON_EXECUTABLE} -B ${LLVMBUILDTOOL}
++  COMMAND ${Python2_EXECUTABLE} -B ${LLVMBUILDTOOL}
+             --native-target "${LLVM_NATIVE_ARCH}"
+             --enable-targets "${LLVM_TARGETS_TO_BUILD}"
+             --enable-optional-components "${LLVMOPTIONALCOMPONENTS}"

--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -264,6 +264,7 @@ class Root(CMakePackage):
     depends_on('vdt',       when='+vdt')
     depends_on('libxml2~python',   when='+xml')
     depends_on('xrootd',    when='+xrootd')
+    depends_on('python@2.7:2.99', when='@6.16', type='build')
     # depends_on('hdfs') - supported (TODO)
 
     # Not supported

--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -65,6 +65,7 @@ class Root(CMakePackage):
     patch('graf2d.patch', level=0)
     patch('external_zlib.patch', level=0, when='@6.12.06')
     patch('root6_16_xrootd.patch', level=0, when='@6.16.00')
+    patch('cmake_python.patch', when="@6.16.00 ^cmake@3.12:")
 
     if sys.platform == 'darwin':
         # Resolve non-standard use of uint, _cf_


### PR DESCRIPTION
On Fedora 31 `jun19` fails as follows:

```
==> Installing root
==> Searching for binary cache of root
==> Warning: No Spack mirrors are currently configured
==> No binary for root found: installing from source
==> Using cached archive: /home/dklein/.spack/source_cache/_source-cache/archive/2a/2a45055c6091adaa72b977c512f84da8ef92723c30837c7e2643eecc9c5ce4d8.tar.gz
==> Staging archive: /tmp/dklein/spack-stage/spack-stage-root-6.16.00-hxk6tq22cf2fmtfrv7dcvmug6brgbalw/root_v6.16.00.source.tar.gz
==> Created stage in /tmp/dklein/spack-stage/spack-stage-root-6.16.00-hxk6tq22cf2fmtfrv7dcvmug6brgbalw
==> Applied patch /home/dklein/projects/FairSoft/packages/root/format-stringbuf-size.patch
==> Applied patch /home/dklein/projects/FairSoft/packages/root/find-mysql.patch
==> Applied patch /home/dklein/projects/FairSoft/packages/root/root7-webgui.patch
==> Applied patch /home/dklein/projects/FairSoft/packages/root/builtin_glew.patch
==> Applied patch /home/dklein/projects/FairSoft/packages/root/builtin_ftgl.patch
==> Applied patch /home/dklein/projects/FairSoft/packages/root/graf3d_gl.patch
==> Applied patch /home/dklein/projects/FairSoft/packages/root/graf2d.patch
==> Applied patch /home/dklein/projects/FairSoft/packages/root/root6_16_xrootd.patch
==> Building root [CMakePackage]
==> Executing phase: 'cmake'
==> Error: ProcessError: Command exited with status 1:
    'cmake' '/tmp/dklein/spack-stage/spack-stage-root-6.16.00-hxk6tq22cf2fmtfrv7dcvmug6brgbalw/spack-src' '-G' 'Unix Makefiles' '-DCMAKE_INSTALL_PREFIX:PATH=/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/root-6.16.00-hxk6tq22cf2fmtfrv7dcvmug6brgbalw' '-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo' '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=FALSE' '-DCMAKE_INSTALL_RPATH:STRING=/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/root-6.16.00-hxk6tq22cf2fmtfrv7dcvmug6brgbalw/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/root-6.16.00-hxk6tq22cf2fmtfrv7dcvmug6brgbalw/lib64;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libuuid-1.0.3-rakurd655i7uve5jtu2c5vtnmzwe2xqz/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxml2-2.9.9-cxsr3tkooyefpmx7vi3wujuazhnmnaxg/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libiconv-1.16-fetha6syhjehrykus3ph6plexqjneqwl/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/xz-5.2.4-neftogfjpigiv4k567ej7mtodmojcqib/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/zlib-1.2.11-wrzfklkgztfq2dvyrj4rmy2f2b2ixscc/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/openssl-1.1.1d-vzdeqvudxjyeybjfg7ui5oq7decmvi2i/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/fontconfig-2.12.3-giwy6bk7z5pvwilph23s7nst6azb2ndi/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/font-util-1.3.2-mbvbprjsar5zfdcay576iabuqaslk7ew/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/freetype-2.10.1-mnx7tcjrcnkvso3iars2xwe3vd3knkyy/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/bzip2-1.0.8-g6j7mao7kpgi4feptxsaa7646ddzkhti/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libpng-1.6.37-j5ikqcbsptjhmszesfghaic5m3oz65kn/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/gsl-2.5-jcojksxhkxk7cdnz2ahylam2ra7mmakw/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/intel-tbb-2019.4-vx5f7b5hasavgirwzynyst4a7tewc3a3/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libice-1.0.9-wz42vk3xcb3pkuki6cf4kogwylvtvggj/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libsm-1.2.2-xlbeqcoc2ggx3ql7fgwp5hvknbepfoyy/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libx11-1.6.7-qgkwbjqrjzutielng7zthn7ins5x7hdw/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/kbproto-1.0.7-qyq2ob2g4sfanzitha32qmkiivkxkudi/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxcb-1.13-e3uwt34xrz6szggw4nhdeh6ue4exexbp/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libpthread-stubs-0.4-pe6us2tyrfs4vjncnz7n3loxomslh6tb/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxau-1.0.8-6hfsk4iiahlcgxdadmivhl43kpunhsrp/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/xproto-7.0.31-ajyzsxcdl7b3iojlynw4ztnuvk36o5df/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxdmcp-1.1.2-sk7h3crajfa5m2kmnfri5i6dsbftzgpx/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libbsd-0.9.1-yrsilvqd4oqnvtjgzae7ythwuytcw5ak/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/xextproto-7.3.0-oracb7ynrcgrgwh7q72guinphybmdtnu/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxext-1.3.3-mrrcfukyux5fc76btg5qzj62dt6eo4si/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxft-2.3.2-l3ppuyzjjrrpht6cwa26kwj5a2zvjskv/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxrender-0.9.10-ycar2c52vilshwn4wxdncgvra37uecvx/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/renderproto-0.11.1-2ml5yb6ymetcdfj4lq6oyxd2wzrsqjs5/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxpm-3.5.12-tyqnwfurfusbgiaagp2k6ywagknb43zn/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/gettext-0.20.1-ho57wcmke3juui7hojnmzskxsz2nwh74/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/ncurses-6.1-kuc2mwycezsjnxu5257qw75bsrvumtyf/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/lz4-1.9.2-6lgpvydd3cp3tc3cyue76e4hsl5bgnft/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/mesa-18.3.6-i24ziiz64icexzpthygrrrgamkuzuoth/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/expat-2.2.9-5fmwvuwba3uvwpuhp4uyi4dwqt2ujgkv/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/llvm-9.0.0-biicfq3fcwsikevhrdfkfne22tcxltra/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/binutils-2.32-5kdocmi6vi76ijrnwkvkh32slb2yalyg/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libedit-3.1-20170329-lbxsjvf2mxjg5s2wxshc5xrzyxezyjel/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pcre-8.42-yfw776ly57rxjygkkgdv4vth46fr67sr/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/mesa-glu-9.0.0-z5ipoyxkcd4knxjyrmdl5qbxzjmpelyd/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/openblas-0.3.7-kdem7d7tpfapndzvfpxkkghwzlhc7xli/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pythia6-428-alice1-cwhi7hjmkquh2e7xjikzkf4j465x4zcl/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pythia8-8240-wro544r5dagk3w6mbdp7o6xykfvqadgv/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/hepmc-2.06.09-45dh77ut7szncccfpfuaiknvf67oefcv/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/unuran-1.8.1-6v6u33agw6udzxvh2et6poq6e3yfg2vb/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/rngstreams-1.0.1-w32vhl4s5iqaekj6lb63p7qimr4rex6y/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/vc-1.4.1-5kkghmt6fwdc3ukxovx5nd3zr2zgykhn/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/xxhash-0.6.5-lbdtsqspgkudloivfu62znompsoj24fg/lib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/davix-0.6.8-rrsnxwgiienlix4xg4goy3w2v2uccdg6/lib64' '-DCMAKE_PREFIX_PATH:STRING=/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/cmake-3.13.4-y3mitzpevbh46uctqexenirnee767otm;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/davix-0.6.8-rrsnxwgiienlix4xg4goy3w2v2uccdg6;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/fontconfig-2.12.3-giwy6bk7z5pvwilph23s7nst6azb2ndi;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/gsl-2.5-jcojksxhkxk7cdnz2ahylam2ra7mmakw;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/intel-tbb-2019.4-vx5f7b5hasavgirwzynyst4a7tewc3a3;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libice-1.0.9-wz42vk3xcb3pkuki6cf4kogwylvtvggj;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libpng-1.6.37-j5ikqcbsptjhmszesfghaic5m3oz65kn;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libsm-1.2.2-xlbeqcoc2ggx3ql7fgwp5hvknbepfoyy;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libx11-1.6.7-qgkwbjqrjzutielng7zthn7ins5x7hdw;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxext-1.3.3-mrrcfukyux5fc76btg5qzj62dt6eo4si;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxft-2.3.2-l3ppuyzjjrrpht6cwa26kwj5a2zvjskv;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxml2-2.9.9-cxsr3tkooyefpmx7vi3wujuazhnmnaxg;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxpm-3.5.12-tyqnwfurfusbgiaagp2k6ywagknb43zn;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/lz4-1.9.2-6lgpvydd3cp3tc3cyue76e4hsl5bgnft;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/mesa-18.3.6-i24ziiz64icexzpthygrrrgamkuzuoth;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/mesa-glu-9.0.0-z5ipoyxkcd4knxjyrmdl5qbxzjmpelyd;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/ncurses-6.1-kuc2mwycezsjnxu5257qw75bsrvumtyf;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/openblas-0.3.7-kdem7d7tpfapndzvfpxkkghwzlhc7xli;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/openssl-1.1.1d-vzdeqvudxjyeybjfg7ui5oq7decmvi2i;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pcre-8.42-yfw776ly57rxjygkkgdv4vth46fr67sr;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pkgconf-1.6.3-qqyetm4vb2sracbqnerx27ij5kryuk5m;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pythia6-428-alice1-cwhi7hjmkquh2e7xjikzkf4j465x4zcl;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pythia8-8240-wro544r5dagk3w6mbdp7o6xykfvqadgv;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/unuran-1.8.1-6v6u33agw6udzxvh2et6poq6e3yfg2vb;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/vc-1.4.1-5kkghmt6fwdc3ukxovx5nd3zr2zgykhn;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/xxhash-0.6.5-lbdtsqspgkudloivfu62znompsoj24fg;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/xz-5.2.4-neftogfjpigiv4k567ej7mtodmojcqib;/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/zlib-1.2.11-wrzfklkgztfq2dvyrj4rmy2f2b2ixscc' '-Dexplicitlink=ON' '-Dexceptions=ON' '-Dfail-on-missing=ON' '-Dshared=ON' '-Dsoversion=ON' '-Dbuiltin_llvm=ON' '-Dbuiltin_afterimage=ON' '-Dasimage:BOOL=ON' '-Dastiff:BOOL=ON' '-Dbuiltin_cfitsio:BOOL=OFF' '-Dbuiltin_davix:BOOL=OFF' '-Dbuiltin_fftw3:BOOL=ON' '-Dbuiltin_freetype:BOOL=ON' '-Dbuiltin_ftgl:BOOL=ON' '-Dbuiltin_gl2ps:BOOL=ON' '-Dbuiltin_glew:BOOL=ON' '-Dbuiltin_gsl:BOOL=OFF' '-Dbuiltin_lzma:BOOL=OFF' '-Dbuiltin_openssl:BOOL=OFF' '-Dbuiltin_pcre:BOOL=OFF' '-Dbuiltin_tbb:BOOL=OFF' '-Dbuiltin_unuran:BOOL=OFF' '-Dbuiltin_vc:BOOL=OFF' '-Dbuiltin_vdt:BOOL=OFF' '-Dbuiltin_veccore:BOOL=OFF' '-Dbuiltin_xrootd:BOOL=ON' '-Dbuiltin_zlib:BOOL=OFF' '-Dbuiltin_lz4:BOOL=OFF' '-Dbuiltin_xxhash:BOOL=OFF' '-Dx11:BOOL=ON' '-Dxft:BOOL=ON' '-Dbonjour:BOOL=OFF' '-Dcocoa:BOOL=OFF' '-Ddavix:BOOL=ON' '-Dfftw3:BOOL=OFF' '-Dfitsio:BOOL=OFF' '-Dfortran:BOOL=ON' '-Dftgl:BOOL=ON' '-Dgdml:BOOL=ON' '-Dgl2ps:BOOL=ON' '-Dgenvector:BOOL=ON' '-Dgminimal:BOOL=ON' '-Dgsl_shared:BOOL=ON' '-Dgviz:BOOL=OFF' '-Dhttp:BOOL=ON' '-Dimt:BOOL=ON' '-Djemalloc:BOOL=OFF' '-Dkrb5:BOOL=OFF' '-Dldap:BOOL=OFF' '-Dlibcxx:BOOL=OFF' '-Dmathmore:BOOL=ON' '-Dmemstat:BOOL=ON' '-Dminimal:BOOL=OFF' '-Dminuit:BOOL=ON' '-Dminuit2:BOOL=ON' '-Dmysql:BOOL=OFF' '-Dodbc:BOOL=OFF' '-Dopengl:BOOL=ON' '-Doracle:BOOL=OFF' '-Dpch:BOOL=OFF' '-Dpgsql:BOOL=OFF' '-Dpythia6:BOOL=ON' '-Dpythia8:BOOL=ON' '-Dpython:BOOL=OFF' '-Dpython3:BOOL=OFF' '-Dqt:BOOL=OFF' '-Dqtgsi:BOOL=OFF' '-Dr:BOOL=OFF' '-Droofit:BOOL=ON' '-Droot7:BOOL=OFF' '-Dwebui:BOOL=OFF' '-Drpath:BOOL=ON' '-Dshadowpw:BOOL=OFF' '-Dsqlite:BOOL=OFF' '-Dssl:BOOL=OFF' '-Dtable:BOOL=OFF' '-Dtbb:BOOL=ON' '-Dtesting:BOOL=OFF' '-Dthread:BOOL=ON' '-Dtmva:BOOL=OFF' '-Dunuran:BOOL=ON' '-Dvc:BOOL=ON' '-Dveccore:BOOL=OFF' '-Dvdt:BOOL=OFF' '-Dxml:BOOL=ON' '-Dxrootd:BOOL=OFF' '-Dafdsmrgd:BOOL=OFF' '-Dafs:BOOL=OFF' '-Dalien:BOOL=OFF' '-Dcastor:BOOL=OFF' '-Dccache:BOOL=OFF' '-Dchirp:BOOL=OFF' '-Dcling:BOOL=ON' '-Ddcache:BOOL=OFF' '-Dgeocad:BOOL=OFF' '-Dgfal:BOOL=OFF' '-Dglite:BOOL=OFF' '-Dglobus:BOOL=OFF' '-Dgnuinstall:BOOL=OFF' '-Dhdfs:BOOL=OFF' '-Dmonalisa:BOOL=OFF' '-Drfio:BOOL=OFF' '-Droottest:BOOL=OFF' '-Druby:BOOL=OFF' '-Druntime_cxxmodules:BOOL=OFF' '-Dsapdb:BOOL=OFF' '-Dsrp:BOOL=OFF' '-Dtcmalloc:BOOL=OFF' '-Dcxx11=ON' '-DGLU_INCLUDE_DIR=/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/mesa-glu-9.0.0-z5ipoyxkcd4knxjyrmdl5qbxzjmpelyd/include' '-DFONTCONFIG_INCLUDE_DIR=/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/fontconfig-2.12.3-giwy6bk7z5pvwilph23s7nst6azb2ndi/include'

1 error found in build log:
     188    -- Doxygen disabled.
     189    -- Go bindings enabled.
     190    -- LLVM host triple: x86_64-unknown-linux-gnu
     191    -- LLVM default target triple: x86_64-unknown-linux-gnu
     192    -- Building with -fPIC
     193    -- Found PythonInterp: /usr/bin/python2.7 (found version "1.4")
  >> 194    CMake Error at interpreter/llvm/src/CMakeLists.txt:614 (message):
     195      Python 2.7 or newer is required
     196
     197
     198    -- Configuring incomplete, errors occurred!
     199    See also "/tmp/dklein/spack-stage/spack-stage-root-6.16.00-hxk6tq22cf2fmtfrv7dcvmug6brgbalw/spack-buil
            d/CMakeFiles/CMakeOutput.log".
     200    See also "/tmp/dklein/spack-stage/spack-stage-root-6.16.00-hxk6tq22cf2fmtfrv7dcvmug6brgbalw/spack-buil
            d/CMakeFiles/CMakeError.log".
```

root was concretized as follows:

```
==> Concretized root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8~python~tmva+vc~vdt
 -   hxk6tq2  root@6.16.00%gcc@9.2.1~aqua~avahi build_type=RelWithDebInfo cxxstd=11 +davix~emacs+examples~fftw~fits+fortran+gdml+gminimal~graphviz+gsl+http~jemalloc~kerberos~ldap~libcxx+math+memstat+minuit~mysql~odbc+opengl patches=0c30f08d161013da4db9cea428d349615e4fe5cfccbf251dee36c8d650356dd6,1bb31e5e8fb6cf5a359e34d4fa3dd10d4c6dc88572a0b409808be235fd393c3e,22af3471f3fd87c0fe8917bf9c811c6d806de6c8b9867d30a1e3d383a1b929d7,2d8600102bae00459982986a483ce0bad1c2d8b813aa13a449a5f758fa0ac88d,45913963bf6d7d3c678eff31e0bc3e018427d6fbb364abcdbb2a24d2bfe94915,8af05dc855ef8b15980838a082e9588a510e9db286d52a3c31f7f57493980acc,b7687b8f80b980e3e70bdf7e747d19055b21bf3b813bb00b8d26a50cba1d357e,e6718077e31ea3b8a36e9421a54889d7a82149e02b8b15aaa771b0eacb7d88a5 ~postgres+pythia6+pythia8~python~qt4~r+roofit~root7+rpath~shadow~sqlite~ssl~table+tbb~test+threads+tiff~tmva+unuran+vc~vdt+x+xml~xrootd arch=linux-fedora31-skylake
[+]  y3mitzp      ^cmake@3.13.4%gcc@9.2.1~doc+ncurses+openssl+ownlibs~qt arch=linux-fedora31-skylake
[+]  kuc2mwy          ^ncurses@6.1%gcc@9.2.1~symlinks~termlib arch=linux-fedora31-skylake
[+]  qqyetm4              ^pkgconf@1.6.3%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  vzdeqvu          ^openssl@1.1.1d%gcc@9.2.1+systemcerts arch=linux-fedora31-skylake
[+]  rjlq56z              ^perl@5.30.0%gcc@9.2.1+cpanm+shared+threads arch=linux-fedora31-skylake
[+]  td7cixz                  ^gdbm@1.18.1%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  js3royg                      ^readline@8.0%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  wrzfklk              ^zlib@1.2.11%gcc@9.2.1+optimize+pic+shared arch=linux-fedora31-skylake
[+]  rrsnxwg      ^davix@0.6.8%gcc@9.2.1 build_type=RelWithDebInfo arch=linux-fedora31-skylake
[+]  rakurd6          ^libuuid@1.0.3%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  cxsr3tk          ^libxml2@2.9.9%gcc@9.2.1~python arch=linux-fedora31-skylake
[+]  fetha6s              ^libiconv@1.16%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  neftogf              ^xz@5.2.4%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  giwy6bk      ^fontconfig@2.12.3%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  mbvbprj          ^font-util@1.3.2%gcc@9.2.1 fonts=encodings,font-adobe-100dpi,font-adobe-75dpi,font-adobe-utopia-100dpi,font-adobe-utopia-75dpi,font-adobe-utopia-type1,font-alias,font-arabic-misc,font-bh-100dpi,font-bh-75dpi,font-bh-lucidatypewriter-100dpi,font-bh-lucidatypewriter-75dpi,font-bh-ttf,font-bh-type1,font-bitstream-100dpi,font-bitstream-75dpi,font-bitstream-speedo,font-bitstream-type1,font-cronyx-cyrillic,font-cursor-misc,font-daewoo-misc,font-dec-misc,font-ibm-type1,font-isas-misc,font-jis-misc,font-micro-misc,font-misc-cyrillic,font-misc-ethiopic,font-misc-meltho,font-misc-misc,font-mutt-misc,font-schumacher-misc,font-screen-cyrillic,font-sun-misc,font-winitzki-cyrillic,font-xfree86-type1 arch=linux-fedora31-skylake
[+]  3xfsaft              ^autoconf@2.69%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  xgcylfy                  ^m4@1.4.18%gcc@9.2.1 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv arch=linux-fedora31-skylake
[+]  htsmbda                      ^libsigsegv@2.12%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  t3wt7ro              ^automake@1.16.1%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  ciiwiha              ^bdftopcf@1.0.5%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  gpt75rr                  ^fontsproto@2.1.3%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  3vfp4fl                      ^util-macros@1.19.1%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  s5ottvp                  ^libxfont@1.5.2%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  mnx7tcj                      ^freetype@2.10.1%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  g6j7mao                          ^bzip2@1.0.8%gcc@9.2.1+shared arch=linux-fedora31-skylake
[+]  rhzq2eg                              ^diffutils@3.7%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  j5ikqcb                          ^libpng@1.6.37%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  ahmqsvi                      ^libfontenc@1.1.3%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  ajyzsxc                          ^xproto@7.0.31%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  ojl5wg3                      ^xtrans@1.3.5%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  e3wnyj2              ^mkfontdir@1.0.7%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  g3d6f6w                  ^mkfontscale@1.1.2%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  j5n6mhc          ^gperf@3.0.4%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  jcojksx      ^gsl@2.5%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  vx5f7b5      ^intel-tbb@2019.4%gcc@9.2.1 cxxstd=default patches=ca08c28bdb15582c30777f9303d1986e4c09b3d514776494f3fbf5f19381bfda,df9770cb0ebf8a084b466eafec9fb17797761e61131ae2e88fac31c0091cbd37 +shared+tm arch=linux-fedora31-skylake
[+]  wz42vk3      ^libice@1.0.9%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  xlbeqco      ^libsm@1.2.2%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  qgkwbjq      ^libx11@1.6.7%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  jf34fty          ^inputproto@2.3.2%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  qyq2ob2          ^kbproto@1.0.7%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  e3uwt34          ^libxcb@1.13%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  pe6us2t              ^libpthread-stubs@0.4%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  6hfsk4i              ^libxau@1.0.8%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  sk7h3cr              ^libxdmcp@1.1.2%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  yrsilvq                  ^libbsd@0.9.1%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  qjskz2j              ^xcb-proto@1.13%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  oracb7y          ^xextproto@7.3.0%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  mrrcfuk      ^libxext@1.3.3%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  l3ppuyz      ^libxft@2.3.2%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  ycar2c5          ^libxrender@0.9.10%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  2ml5yb6              ^renderproto@0.11.1%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  tyqnwfu      ^libxpm@3.5.12%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  ho57wcm          ^gettext@0.20.1%gcc@9.2.1+bzip2+curses+git~libunistring+libxml2+tar+xz arch=linux-fedora31-skylake
[+]  5jaxlka              ^tar@1.32%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  6lgpvyd      ^lz4@1.9.2%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  i24ziiz      ^mesa@18.3.6%gcc@9.2.1+glx+llvm+opengl~opengles+osmesa patches=55a5611ca9fcbe8324c4d68a07b338134954ff12c5b122dc78ff376f012a1414 swr=none arch=linux-fedora31-skylake
[+]  5kdocmi          ^binutils@2.32%gcc@9.2.1+gold~headers~libiberty+nls~plugins arch=linux-fedora31-skylake
[+]  5tuvr4j          ^bison@3.4.2%gcc@9.2.1 patches=89aa362716d898edd0b5c6ae4208dc1b6992887774848a09e8021afd676f7d61 arch=linux-fedora31-skylake
[+]  vdyrb3r              ^help2man@1.47.11%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  5fmwvuw          ^expat@2.2.9%gcc@9.2.1+libbsd arch=linux-fedora31-skylake
[+]  btz34mi          ^flex@2.6.4%gcc@9.2.1+lex patches=09c22e5c6fef327d3e48eb23f0d610dcd3a35ab9207f12e0f875701c677978d3 arch=linux-fedora31-skylake
[+]  7nucsmx              ^libtool@2.4.6%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  eaiyswi          ^glproto@1.4.17%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  biicfq3          ^llvm@9.0.0%gcc@9.2.1~all_targets build_type=Release +clang+compiler-rt+gold+internal_unwind+libcxx~link_dylib+lld+lldb~omp_tsan+polly~python~shared_libs arch=linux-fedora31-skylake
[+]  lbxsjvf              ^libedit@3.1-20170329%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  7w45bgv              ^perl-data-dumper@2.173%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  74msar7              ^python@3.7.4%gcc@9.2.1+bz2+ctypes+dbm+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4~uuid+zlib arch=linux-fedora31-skylake
[+]  s2764ye                  ^libffi@3.2.1%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  mfd7vba                  ^sqlite@3.30.1%gcc@9.2.1~column_metadata+fts~functions~rtree arch=linux-fedora31-skylake
[+]  snzyvhf              ^swig@4.0.0%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  yfw776l                  ^pcre@8.42%gcc@9.2.1+jit+multibyte+utf arch=linux-fedora31-skylake
[+]  mfak2tu          ^py-mako@1.0.4%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  2fawwnw              ^py-markupsafe@1.1.1%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  3cnkkj6                  ^py-setuptools@41.4.0%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  z5ipoyx      ^mesa-glu@9.0.0%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  kdem7d7      ^openblas@0.3.7%gcc@9.2.1+avx2~avx512 cpu_target=auto ~ilp64+pic+shared threads=none ~virtual_machine arch=linux-fedora31-skylake
[+]  cwhi7hj      ^pythia6@428-alice1%gcc@9.2.1 build_type=RelWithDebInfo arch=linux-fedora31-skylake
[+]  wro544r      ^pythia8@8240%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  45dh77u          ^hepmc@2.06.09%gcc@9.2.1 build_type=RelWithDebInfo length=CM momentum=GEV arch=linux-fedora31-skylake
[+]  275nfwb          ^rsync@3.1.3%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  6v6u33a      ^unuran@1.8.1%gcc@9.2.1~gsl+rngstreams+shared arch=linux-fedora31-skylake
[+]  w32vhl4          ^rngstreams@1.0.1%gcc@9.2.1 arch=linux-fedora31-skylake
[+]  5kkghmt      ^vc@1.4.1%gcc@9.2.1 build_type=RelWithDebInfo arch=linux-fedora31-skylake
[+]  lbdtsqs      ^xxhash@0.6.5%gcc@9.2.1 arch=linux-fedora31-skylake
```

The `$PATH` spack presents to the root packages is (I added some line breaks for readibility):

```
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/python-3.7.4-74msar7dt4uoxjc2goesgp7wnmrtgiki/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/perl-5.30.0-rjlq56zitkw2lbhtr4jkib6ht2jsbpuo/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/perl-data-dumper-2.173-7w45bgvgnfnmfyll6jnicdqdskkefooz/bin:
/home/dklein/projects/FairSoft/spack/lib/spack/env/gcc:
/home/dklein/projects/FairSoft/spack/lib/spack/env/case-insensitive:
/home/dklein/projects/FairSoft/spack/lib/spack/env:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libpng-1.6.37-j5ikqcbsptjhmszesfghaic5m3oz65kn/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pcre-8.42-yfw776ly57rxjygkkgdv4vth46fr67sr/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/ncurses-6.1-kuc2mwycezsjnxu5257qw75bsrvumtyf/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/davix-0.6.8-rrsnxwgiienlix4xg4goy3w2v2uccdg6/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxpm-3.5.12-tyqnwfurfusbgiaagp2k6ywagknb43zn/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxml2-2.9.9-cxsr3tkooyefpmx7vi3wujuazhnmnaxg/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/gsl-2.5-jcojksxhkxk7cdnz2ahylam2ra7mmakw/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/xz-5.2.4-neftogfjpigiv4k567ej7mtodmojcqib/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pkgconf-1.6.3-qqyetm4vb2sracbqnerx27ij5kryuk5m/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/xxhash-0.6.5-lbdtsqspgkudloivfu62znompsoj24fg/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/lz4-1.9.2-6lgpvydd3cp3tc3cyue76e4hsl5bgnft/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/openblas-0.3.7-kdem7d7tpfapndzvfpxkkghwzlhc7xli/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/openssl-1.1.1d-vzdeqvudxjyeybjfg7ui5oq7decmvi2i/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/cmake-3.13.4-y3mitzpevbh46uctqexenirnee767otm/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/fontconfig-2.12.3-giwy6bk7z5pvwilph23s7nst6azb2ndi/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pythia8-8240-wro544r5dagk3w6mbdp7o6xykfvqadgv/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libpng-1.6.37-j5ikqcbsptjhmszesfghaic5m3oz65kn/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pcre-8.42-yfw776ly57rxjygkkgdv4vth46fr67sr/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/ncurses-6.1-kuc2mwycezsjnxu5257qw75bsrvumtyf/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/davix-0.6.8-rrsnxwgiienlix4xg4goy3w2v2uccdg6/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxpm-3.5.12-tyqnwfurfusbgiaagp2k6ywagknb43zn/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/libxml2-2.9.9-cxsr3tkooyefpmx7vi3wujuazhnmnaxg/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/gsl-2.5-jcojksxhkxk7cdnz2ahylam2ra7mmakw/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/xz-5.2.4-neftogfjpigiv4k567ej7mtodmojcqib/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pkgconf-1.6.3-qqyetm4vb2sracbqnerx27ij5kryuk5m/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/xxhash-0.6.5-lbdtsqspgkudloivfu62znompsoj24fg/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/lz4-1.9.2-6lgpvydd3cp3tc3cyue76e4hsl5bgnft/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/openblas-0.3.7-kdem7d7tpfapndzvfpxkkghwzlhc7xli/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/openssl-1.1.1d-vzdeqvudxjyeybjfg7ui5oq7decmvi2i/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/cmake-3.13.4-y3mitzpevbh46uctqexenirnee767otm/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/fontconfig-2.12.3-giwy6bk7z5pvwilph23s7nst6azb2ndi/bin:
/home/dklein/.spack/install_tree/linux-fedora31-skylake/gcc-9.2.1/pythia8-8240-wro544r5dagk3w6mbdp7o6xykfvqadgv/bin:
/home/dklein/projects/FairSoft/spack/bin:
/home/dklein/go/bin:
/home/dklein/.local/bin:
/home/dklein/bin:
/home/dklein/.cargo/bin:
/home/dklein/go/bin:
/home/dklein/.local/bin:
/home/dklein/bin:
/home/dklein/.cargo/bin:
/home/dklein/.rvm/gems/ruby-2.6.0/bin:
/home/dklein/.rvm/gems/ruby-2.6.0@global/bin:
/home/dklein/.rvm/rubies/ruby-2.6.0/bin:
/usr/share/Modules/bin:
/usr/lib64/ccache:
/usr/local/bin:
/usr/local/sbin:
/usr/bin:
/usr/sbin:
/home/dklein/bin:
/home/dklein/.rvm/bin:
/home/dklein/.fzf/bin:
/home/dklein/.rvm/bin:
/home/dklein/bin:
/home/dklein/.rvm/bin
```

When I try to set the `$PATH` from above in my shell, it breaks the shell - `sed` and `grep` are no longer found which are used by the script that generates my shell prompt.

System Python is available in various versions:

```
$ which python && python --version
/usr/bin/python
Python 3.7.5
$ which python2 && python2 --version
/usr/bin/python2
Python 2.7.17
$ which python3 && python3 --version
/usr/bin/python3
Python 3.7.5
$ which python2.7 && python2.7 --version
/usr/bin/python2.7
Python 2.7.17
$ which python3.7 && python3.7 --version
/usr/bin/python3.7
Python 3.7.5

```

One of the proposed commits fixes the issue by specifying an explicit dependency on Python 2. AFAICS, the `python` variant of the root package is a switch whether to build the Root/Python bindings. So, even with `~python` root still has a build dependency to Python, to be more precise: The embedded llvm has a dependency to Python 2: 
https://github.com/root-project/root/blob/03dac90ff57a06bc0156bc2d405aaf9e276353a6/interpreter/llvm/src/CMakeLists.txt#L601-L615

Does anybody recognize the error or knows a better solution?

Is there any length restriction on the `$PATH` variable? 