### PR TITLE
Add python2 build dependency for root@6.16

### DIFF
--- a/env/jun19/sim_no-threads.yaml
+++ b/env/jun19/sim_no-threads.yaml
@@ -1,11 +1,12 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt~python~tmva]
+      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt~python~tmva ^mesa~llvm]
     - when: platform == 'darwin'
       root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt~python~tmva+aqua]
   specs:
     - pcre+jit
+    - python@2.7.16
     - cmake@3.13.4
     - googletest@1.8.1
     - boost@1.68.0

--- a/env/jun19/sim_threads.yaml
+++ b/env/jun19/sim_threads.yaml
@@ -1,11 +1,12 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt~python~tmva]
+      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt~python~tmva ^mesa~llvm]
     - when: platform == 'darwin'
       root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt~python~tmva+aqua]
   specs:
     - pcre+jit
+    - python@2.7.16
     - cmake@3.13.4
     - googletest@1.8.1
     - boost@1.68.0

--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -251,7 +251,8 @@ class Root(CMakePackage):
     depends_on('postgresql', when='+postgres')
     depends_on('pythia6',  when='+pythia6')
     depends_on('pythia8',   when='+pythia8')
-    depends_on('python@2.7:',     when='+python', type=('build', 'run'))
+    depends_on('python@2.7:2.99',     when='@6.16', type=('build', 'run'))
+    depends_on('python@2.7:', when='@6.18:+python', type=('build', 'run'))
     depends_on('r',         when='+r', type=('build', 'run'))
     depends_on('r-cpp',     when='+r', type=('build', 'run'))
     depends_on('r-inside',  when='+r', type=('build', 'run'))
@@ -505,7 +506,7 @@ class Root(CMakePackage):
             options.append('-DCMAKE_PROGRAM_PATH={0}'.format(
                 self.spec['mysql-client'].prefix.bin))
 
-        if '+python' in self.spec:
+        if '+python' in self.spec or '@6.16' in self.spec:
             options.append('-DPYTHON_EXECUTABLE={0}/python'.format(
                 self.spec['python'].prefix.bin))
 


### PR DESCRIPTION
Build mesa without llvm on linux
Build python@2.7.16 as build dependency for root.
Fix both in jun19 environments.
In root recipe, if @6.16 then pass PYTHON_EXECUTABLE