### PR TITLE
CI: Backup stage/ into build/ ; Add Ubuntu18.04 and Debian8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,14 +29,19 @@ execute_process(COMMAND mktemp -d
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 message(STATUS "Directory for this test run: ${TEST_TARGETDIR}")
 
-macro(fs_test_props testname)
+function(fs_test_props_base testname)
   set_property(TEST ${testname} APPEND PROPERTY ENVIRONMENT
                TARGETDIR=${TEST_TARGETDIR})
+  set_property(TEST ${testname} APPEND PROPERTY ENVIRONMENT
+               CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR})
+endfunction()
+function(fs_test_props testname)
+  fs_test_props_base(${testname})
   set_property(TEST ${testname} APPEND PROPERTY
                FIXTURES_REQUIRED fixture.main)
   set_property(TEST ${testname} APPEND PROPERTY
                TIMEOUT 10800)
-endmacro()
+endfunction()
 function(fs_test_simple)
   cmake_parse_arguments(ARGS "" "NAME" "SPEC" ${ARGN})
   add_test(NAME simple.${ARGS_NAME}
@@ -71,7 +76,6 @@ fs_test_env(NAME jun19.nothreads ENVFILE env/jun19/sim_no-threads.yaml)
 add_test(NAME test.cleanup
          COMMAND test/buildcleanup.sh
          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-set_property(TEST test.cleanup APPEND PROPERTY ENVIRONMENT
-             TARGETDIR=${TEST_TARGETDIR})
+fs_test_props_base(test.cleanup)
 set_property(TEST test.cleanup APPEND PROPERTY
              FIXTURES_CLEANUP fixture.main)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,8 @@ pipeline {
           def ctestcmd = "ctest -VV -S FairSoft_test.cmake"
           def linux_jobs = jobMatrix('slurm', ctestcmd, [
             [os: 'Fedora30', container: 'fedora.30.sif'],
+            [os: 'Ubuntu-18.04-LTS', container: 'ubuntu.18.04.sif'],
+            [os: 'Debian8', container: 'debian.8.sif'],
           ]) { spec, label, jobsh ->
             sh """
               echo "*** Submitting at: \$(date -R)"

--- a/test/buildcleanup.sh
+++ b/test/buildcleanup.sh
@@ -6,6 +6,10 @@ installedMB="$(cd $HOME/install-tree && du -ms . | sed -e 's/[	 ].*$//')"
 rm -rf "$HOME/install-tree"
 
 stageKB="$(cd $HOME/stage && du -ks . | sed -e 's/[	 ].*$//')"
+(cd "$HOME" && tar -cjf "stage.tar.bz2" stage) \
+	&& mv "$HOME/stage.tar.bz2" "$CMAKE_BINARY_DIR/" \
+	&& ls -l "$CMAKE_BINARY_DIR/stage.tar.bz2" \
+	&& rm -rf "$HOME/stage"
 
 echo ""
 echo "<DartMeasurement name=\"installedMB\" type=\"numeric/double\">$installedMB</DartMeasurement>"

--- a/test/buildsetup.sh
+++ b/test/buildsetup.sh
@@ -8,6 +8,10 @@ then
 	fi
 fi
 
+echo "*** LABEL: $LABEL"
+echo -n "*** Host : "
+hostname -f
+
 # echo "==> Environment:"
 # env | sed -e 's/^/==>  | /'
 

--- a/test/container/debian.8.def
+++ b/test/container/debian.8.def
@@ -1,8 +1,8 @@
 # Rebuild:
-#   singularity build -f -F ubuntu.18.04.sif ubuntu.18.04.def
+#   singularity build -f -F debian.8.sif debian.8.def
 
 Bootstrap: docker
-From: ubuntu:18.04
+From: debian:8
 
 %post
     apt-get update
@@ -10,5 +10,4 @@ From: ubuntu:18.04
     apt-get -y --no-install-recommends install sed curl ca-certificates wget xz-utils bzip2 gzip unzip tar
     apt-get -y --no-install-recommends install python3 g++ gcc gfortran make patch git
     # Things for our testing system:
-    apt-get -y --no-install-recommends install cmake hostname lsb-release
-    apt-get -y clean
+    apt-get -y install cmake hostname lsb-release


### PR DESCRIPTION
In case of failures during spack installs, the `stage/`-area is left as is and contains the last state of the build including logs (from spack and the build system). This can be very helpful in analyzing build problems.

So at the end tar the whole `stage/` directory into a `stage.tar.bz2` in the `build/` directory. This is usually an area, that's easier to find.
And show the full path.

Also some minor refactoring and improvements for multiple containers.
