### PR TITLE
Build root with tmva support

### DIFF
--- a/env/dev/sim_no-threads.yaml
+++ b/env/dev/sim_no-threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~python~tmva]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~python~tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1

--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~python~tmva]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~python~tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~x~opengl~python~tmva]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~x~opengl+python+tmva]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~x~opengl~python~tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~x~opengl+python+tmva+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1

--- a/env/jun19/sim_no-threads.yaml
+++ b/env/jun19/sim_no-threads.yaml
@@ -1,12 +1,13 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt~python~tmva ^mesa~llvm]
+      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt~python~tmva+aqua]
+      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - python@2.7.16
+    - py-numpy@1.16.5
     - googletest@1.8.1
     - boost@1.68.0
     - fairlogger@1.4.0

--- a/env/jun19/sim_threads.yaml
+++ b/env/jun19/sim_threads.yaml
@@ -1,12 +1,13 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt~python~tmva ^mesa~llvm]
+      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt~python~tmva+aqua]
+      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - python@2.7.16
+    - py-numpy@1.16.5
     - googletest@1.8.1
     - boost@1.68.0
     - fairlogger@1.4.0


### PR DESCRIPTION
PANDA needs root with tmva.

Previously, the idea was to skip tmva in order to avoid python dependency completely. Now we have it anyhow, event pinned down in jun19 environments. So it does not change a lot having tmva feature on again.