### PR TITLE
fairroot: Support building against shared flatbuffer lib

### DIFF
--- a/packages/fairroot/link_against_flatbuffers_shared.patch
+++ b/packages/fairroot/link_against_flatbuffers_shared.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index acccf5314..a5a0979bd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -514,7 +514,7 @@ if(PROJECT_PACKAGE_DEPENDENCIES)
+       get_target_property(fmt_include fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+       get_filename_component(prefix ${fmt_include}/.. ABSOLUTE)
+     elseif(${dep} STREQUAL Flatbuffers)
+-      get_target_property(flatbuffers_include flatbuffers::flatbuffers INTERFACE_INCLUDE_DIRECTORIES)
++      get_target_property(flatbuffers_include flatbuffers::flatbuffers_shared INTERFACE_INCLUDE_DIRECTORIES)
+       get_filename_component(prefix ${flatbuffers_include}/.. ABSOLUTE)
+     endif()
+ 
+diff --git a/examples/advanced/Tutorial3/CMakeLists.txt b/examples/advanced/Tutorial3/CMakeLists.txt
+index 56576a663..c1f534c0e 100644
+--- a/examples/advanced/Tutorial3/CMakeLists.txt
++++ b/examples/advanced/Tutorial3/CMakeLists.txt
+@@ -124,7 +124,7 @@ target_link_libraries(${target} PUBLIC
+ 
+   Boost::serialization
+   $<$<BOOL:${Protobuf_FOUND}>:protobuf::libprotobuf>
+-  $<$<BOOL:${Flatbuffers_FOUND}>:flatbuffers::flatbuffers>
++  $<$<BOOL:${Flatbuffers_FOUND}>:flatbuffers::flatbuffers_shared>
+   $<$<BOOL:${msgpack_FOUND}>:msgpackc>
+ 
+   Core # Rtypes

--- a/packages/fairroot/package.py
+++ b/packages/fairroot/package.py
@@ -65,6 +65,7 @@ class Fairroot(CMakePackage):
 #    depends_on('millepede')
 
     patch('CMake.patch', level=0, when="@18.0.6")
+    patch('link_against_flatbuffers_shared.patch', when="@develop")
 
     def setup_environment(self, spack_env, run_env):
         stdversion=('-std=c++%s' % self.spec.variants['cxxstd'].value)


### PR DESCRIPTION
Fix on package level for now to unblock the work towards upcoming releases. Maybe I will find the time to fix it properly upstream and separate from FairRootGroup/FairRoot#933 before the FairSoft release, then this can go away again.