### PR TITLE
Limit number of executors for those long running jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,9 @@ pipeline {
               ${ctestcmd}
             """
           }
-          parallel(linux_jobs + macos_jobs)
+          throttle(['long']) {
+            parallel(linux_jobs + macos_jobs)
+          }
         }
       }
     }


### PR DESCRIPTION
Trying the https://plugins.jenkins.io/throttle-concurrents/ plugin. Will start the CI later manually to learn if this does what I think it does.