### PR TITLE
fairroot: Improve Dependencies

### DIFF
--- a/env/dev/r3broot.yaml
+++ b/env/dev/r3broot.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - python@2.7.16

--- a/env/dev/sim_no-threads.yaml
+++ b/env/dev/sim_no-threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1

--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~x~opengl+python+tmva]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt~x~opengl+python+tmva]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~x~opengl+python+tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt~x~opengl+python+tmva+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1

--- a/env/jun19/sim_no-threads.yaml
+++ b/env/jun19/sim_no-threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - python@2.7.16

--- a/env/jun19/sim_threads.yaml
+++ b/env/jun19/sim_threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.16.00+fortran+gdml+http+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - python@2.7.16

--- a/packages/fairroot/package.py
+++ b/packages/fairroot/package.py
@@ -35,7 +35,6 @@ class Fairroot(CMakePackage):
     patch('cmake_utf8.patch', when='@18.2.1')
 
     # Dependencies which are same for all versions
-    depends_on('gnutls ~guile') #dependency of cmake which has to be build without guile support
     depends_on('cmake@3.13.4: +ownlibs', type='build')
     depends_on('googletest@1.8.1:')
 
@@ -53,7 +52,7 @@ class Fairroot(CMakePackage):
 
     depends_on('geant4', when="+sim")
 
-    depends_on('root')
+    depends_on('root+http')
 
     depends_on('geant3', when="+sim")
     depends_on('vgm', when="+sim")


### PR DESCRIPTION
* fairroot needs `root+http` in my tests, so moved the `+http` from every environment over to fairroot.

* fairroot compiles fine without gnutls and the comment on the `depends_on` suggests, that this was a concretizer hint. So dropped it.