### PR TITLE
fairroot: Add examples Variant

### DIFF
--- a/env/dev/sim_no-threads.yaml
+++ b/env/dev/sim_no-threads.yaml
@@ -15,6 +15,6 @@ spack:
     - geant3@v3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0
-    - fairroot@develop+sim
+    - fairroot@develop+sim+examples
   concretization: together
   view: false

--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -15,6 +15,6 @@ spack:
     - geant3@v3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0
-    - fairroot@develop+sim
+    - fairroot@develop+sim+examples
   concretization: together
   view: false

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -15,6 +15,6 @@ spack:
     - geant3@v3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0
-    - fairroot@develop+sim
+    - fairroot@develop+sim+examples
   concretization: together
   view: false

--- a/env/jun19/sim_no-threads.yaml
+++ b/env/jun19/sim_no-threads.yaml
@@ -21,6 +21,6 @@ spack:
     - geant3@v2-7_fairsoft
     - vgm@4-5
     - geant4_vmc@4-0-p1
-    - fairroot@18.2.1+sim
+    - fairroot@18.2.1+sim+examples
   concretization: together
   view: false

--- a/env/jun19/sim_threads.yaml
+++ b/env/jun19/sim_threads.yaml
@@ -21,6 +21,6 @@ spack:
     - geant3@v2-7_fairsoft
     - vgm@4-5
     - geant4_vmc@4-0-p1
-    - fairroot@18.2.1+sim
+    - fairroot@18.2.1+sim+examples
   concretization: together
   view: false

--- a/packages/fairroot/fairlogger_incdir.patch
+++ b/packages/fairroot/fairlogger_incdir.patch
@@ -1,0 +1,10 @@
+--- examples/common/mcstack/CMakeLists.txt~	2019-08-21 15:07:36.000000000 +0200
++++ examples/common/mcstack/CMakeLists.txt	2020-04-20 13:22:22.448247543 +0200
+@@ -12,6 +12,7 @@
+ Set(INCLUDE_DIRECTORIES
+   ${BASE_INCLUDE_DIRECTORIES}
+   ${CMAKE_SOURCE_DIR}/examples/common/mcstack
++  ${FairLogger_INCDIR}
+ )
+ 
+ Include_Directories(${INCLUDE_DIRECTORIES})

--- a/packages/fairroot/package.py
+++ b/packages/fairroot/package.py
@@ -31,8 +31,7 @@ class Fairroot(CMakePackage):
             description='Use the specified C++ standard when building.')
 
     variant('sim', default=True, description='Enable simulation engines and event generators')
-
-    patch('cmake_utf8.patch', when='@18.2.1')
+    variant('examples', default=False, description='Install examples')
 
     # Dependencies which are same for all versions
     depends_on('cmake@3.13.4: +ownlibs', type='build')
@@ -66,6 +65,7 @@ class Fairroot(CMakePackage):
 #    depends_on('millepede')
 
     patch('CMake.patch', level=0, when="@18.0.6")
+    patch('cmake_utf8.patch', when='@18.2.1')
     patch('link_against_flatbuffers_shared.patch', when="@develop")
 
     def setup_environment(self, spack_env, run_env):
@@ -94,7 +94,8 @@ class Fairroot(CMakePackage):
         options.append('-DFlatbuffers_DIR={0}'.format(
         self.spec['flatbuffers'].prefix))
         options.append('-DDISABLE_GO=ON')
-        options.append('-DBUILD_EXAMPLES=OFF')
+        options.append('-DBUILD_EXAMPLES:BOOL=%s' %
+                       ('ON' if '+examples' in self.spec else 'OFF'))
         options.append('-DFAIRROOT_MODULAR_BUILD=ON')
         options.append('-DBoost_NO_SYSTEM_PATHS=TRUE')
         options.append('-DCMAKE_EXPORT_COMPILE_COMMANDS=ON')

--- a/packages/fairroot/package.py
+++ b/packages/fairroot/package.py
@@ -13,7 +13,6 @@ from spack import *
 class Fairroot(CMakePackage):
     """C++ simulation, reconstruction and analysis framework for particle physics experiments """
 
-
     homepage = "http://fairroot.gsi.de"
     url      = "https://github.com/FairRootGroup/FairRoot/archive/v18.0.6.tar.gz"
     git      = "https://github.com/FairRootGroup/FairRoot.git"
@@ -66,6 +65,7 @@ class Fairroot(CMakePackage):
 
     patch('CMake.patch', level=0, when="@18.0.6")
     patch('cmake_utf8.patch', when='@18.2.1')
+    patch('fairlogger_incdir.patch', level=0, when='@18.2.1')
     patch('link_against_flatbuffers_shared.patch', when="@develop")
 
     def setup_environment(self, spack_env, run_env):


### PR DESCRIPTION
Especially for our public "fairroot" container, we want the examples to be built and installed.

On the other hand, experiments do not need them, they have their own examples.

* So added a variant to enable the examples in fairroot.
* Enabled this variant in the standard fairroot environments, so that we test this and have them there for the user.