### PR TITLE
vmc: new Version, Improve Dictionary Generation

### DIFF
--- a/env/dev/sim_no-threads.yaml
+++ b/env/dev/sim_no-threads.yaml
@@ -11,7 +11,7 @@ spack:
     - pythia8@8301
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep~threads
     - $root
-    - vmc@1-0
+    - vmc@1-0-p1
     - geant3@v3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0

--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -11,7 +11,7 @@ spack:
     - pythia8@8301
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root
-    - vmc@1-0
+    - vmc@1-0-p1
     - geant3@v3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -11,7 +11,7 @@ spack:
     - pythia8@8301
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root
-    - vmc@1-0
+    - vmc@1-0-p1
     - geant3@v3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0

--- a/packages/vmc/dict_fixes_101.patch
+++ b/packages/vmc/dict_fixes_101.patch
@@ -1,0 +1,44 @@
+--- spack-src/source/CMakeLists.txt
++++ spack-src/source/CMakeLists.txt
+@@ -45,24 +45,24 @@
+ #
+ ROOT_GENERATE_DICTIONARY(
+   ${library_name}_dict
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TGeoMCBranchArrayContainer.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TGeoMCGeometry.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCAutoLock.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCManager.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCManagerStack.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCOptical.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCParticleStatus.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCParticleType.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCProcess.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCVerbose.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TMCtls.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TVirtualMC.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TVirtualMCApplication.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TVirtualMCGeometry.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TVirtualMCSensitiveDetector.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include/TVirtualMCStack.h
++  TGeoMCBranchArrayContainer.h
++  TGeoMCGeometry.h
++  TMCAutoLock.h
++  TMCManager.h
++  TMCManagerStack.h
++  TMCOptical.h
++  TMCParticleStatus.h
++  TMCParticleType.h
++  TMCProcess.h
++  TMCVerbose.h
++  TMCtls.h
++  TVirtualMC.h
++  TVirtualMCApplication.h
++  TVirtualMCGeometry.h
++  TVirtualMCSensitiveDetector.h
++  TVirtualMCStack.h
+   MODULE ${library_name}
+-  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/include/LinkDef.h)
++  LINKDEF include/LinkDef.h)
+ 
+ # Files produced by the dictionary generation
+ SET(root_dict

--- a/packages/vmc/dict_fixes_101.patch
+++ b/packages/vmc/dict_fixes_101.patch
@@ -42,3 +42,15 @@
  
  # Files produced by the dictionary generation
  SET(root_dict
+--- spack-src/source/CMakeLists.txt
++++ spack-src/source/CMakeLists.txt
+@@ -63,6 +63,9 @@
+   TVirtualMCSensitiveDetector.h
+   TVirtualMCStack.h
+   MODULE ${library_name}
++  OPTIONS "-I${CMAKE_INSTALL_PREFIX}/include/${base_name}"
++    -excludePath "${CMAKE_CURRENT_BINARY_DIR}"
++    -excludePath "${PROJECT_SOURCE_DIR}/source"
+   LINKDEF include/LinkDef.h)
+ 
+ # Files produced by the dictionary generation

--- a/packages/vmc/package.py
+++ b/packages/vmc/package.py
@@ -10,6 +10,7 @@ class Vmc(CMakePackage):
     """The Virtual Monte Carlo core library"""
 
     homepage = "https://github.com/vmc-project/vmc"
+    git      = 'https://github.com/vmc-project/vmc.git'
     url      = "https://github.com/vmc-project/vmc/archive/v1-0.tar.gz"
 
     version('1-0-p1', sha256='4a20515f7de426797955cec4a271958b07afbaa330770eeefb5805c882ad9749')
@@ -18,3 +19,16 @@ class Vmc(CMakePackage):
     patch('dict_fixes_101.patch', when='@1-0-p1')
 
     depends_on('root@6.18.04:')
+
+    def common_env_setup(self, env):
+        # So that root finds the shared library / rootmap
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
+
+    def setup_run_environment(self, env):
+        self.common_env_setup(env)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.common_env_setup(env)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        self.common_env_setup(env)

--- a/packages/vmc/package.py
+++ b/packages/vmc/package.py
@@ -12,6 +12,7 @@ class Vmc(CMakePackage):
     homepage = "https://github.com/vmc-project/vmc"
     url      = "https://github.com/vmc-project/vmc/archive/v1-0.tar.gz"
 
+    version('1-0-p1', sha256='4a20515f7de426797955cec4a271958b07afbaa330770eeefb5805c882ad9749')
     version('1-0', sha256='3da58518b32db1b503082e3205884802a1a263a915071b96e3fd67861db3ca40')
 
     depends_on('root@6.18.04:')

--- a/packages/vmc/package.py
+++ b/packages/vmc/package.py
@@ -15,4 +15,6 @@ class Vmc(CMakePackage):
     version('1-0-p1', sha256='4a20515f7de426797955cec4a271958b07afbaa330770eeefb5805c882ad9749')
     version('1-0', sha256='3da58518b32db1b503082e3205884802a1a263a915071b96e3fd67861db3ca40')
 
+    patch('dict_fixes_101.patch', when='@1-0-p1')
+
     depends_on('root@6.18.04:')


### PR DESCRIPTION
### Add version 1-0-p1

This version adds a fix for root dictionaries.
This improves using vmc in the root interpreter.

Problem with 1-0:
```console
root [0] TMCManager *tmc;
Error in <TInterpreter::TCling::AutoLoad>: failure loading library libVM
```

With 1-0-p1 there are now problems with headers: When the source/build tree exists, everything works fine. But if it is removed, then headers are not found, even with `ROOT_INCLUDE_PATH` set.

### Make Header Paths in Dictionary Relative

According to

https://root.cern/doc/v618/release-notes.html#header-location-and-root_generate_dictionary-root_standard_library_package

the listed headers in ROOT_GENERATE_DICTIONARY should use relative paths for the listed headers.

With this change, the headers in the install tree are found by the interpreter, when `ROOT_INCLUDE_PATH` is set.

### Let Headers be Searched in the Install Tree

When loading a module in the root interpreter, it needs to load some more headers.
Those headers are searched for in $ROOT_INCLUDE_PATH and a list of paths inside the shared library module.

The list of paths gets all the entries from the include search path (`-I` arguments) and then is reduced by the `-excludePath` options to `rootcling`.

So the idea is:
* Add the install tree path to the _end_ of the `-I` list, so that during generation the source tree headers are being used.
* Use `-excludePath` to remove nearly all source/build paths from the list that is being stored in the shared library. This way, there is no security problem with searching in the source/build tree.