### PR TITLE
Fixes for ROOT dictionaries and pythia building/using

### DIFF
--- a/env/dev/sim_no-threads.yaml
+++ b/env/dev/sim_no-threads.yaml
@@ -14,7 +14,7 @@ spack:
     - vmc@1-0-p1
     - geant3@v3-0_fairsoft
     - vgm@4-7
-    - geant4_vmc@5-0
+    - geant4_vmc@5-0-p1
     - fairroot@18.4.0+sim+examples
   concretization: together
   view: false

--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -14,7 +14,7 @@ spack:
     - vmc@1-0-p1
     - geant3@v3-0_fairsoft
     - vgm@4-7
-    - geant4_vmc@5-0
+    - geant4_vmc@5-0-p1
     - fairroot@18.4.0+sim+examples
   concretization: together
   view: false

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -14,7 +14,7 @@ spack:
     - vmc@1-0-p1
     - geant3@v3-0_fairsoft
     - vgm@4-7
-    - geant4_vmc@5-0
+    - geant4_vmc@5-0-p1
     - fairroot@18.4.0+sim+examples
   concretization: together
   view: false

--- a/packages/fairroot/package.py
+++ b/packages/fairroot/package.py
@@ -83,6 +83,7 @@ class Fairroot(CMakePackage):
         self.spec['root'].prefix))
         options.append('-DPythia6_LIBRARY_DIR={0}/lib'.format(
         self.spec['pythia6'].prefix))
+        options.append('-DPYTHIA8_DIR={0}'.format(self.spec['pythia8'].prefix))
         options.append('-DGeant3_DIR={0}'.format(
         self.spec['geant3'].prefix))
         options.append('-DGeant4_DIR={0}'.format(

--- a/packages/geant3/dict_fixes_30.patch
+++ b/packages/geant3/dict_fixes_30.patch
@@ -1,0 +1,57 @@
+--- spack-src/cmake/Geant3BuildLibrary.cmake
++++ spack-src/cmake/Geant3BuildLibrary.cmake
+@@ -44,6 +44,7 @@
+   ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/TGeant3gu.h
+   ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/TGeant3.h
+   ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/TGeant3TGeo.h
++  MODULE ${library_name}
+   LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/geant3LinkDef.h)
+ 
+ # Files produced by the dictionary generation
+@@ -51,8 +51,8 @@
+ SET(root_dict
+   ${library_name}_dict.cxx)
+ SET(root_dict_libs
+-  ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${library_name}_dict_rdict.pcm
+-  ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${library_name}_dict.rootmap)
++  ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${library_name}_rdict.pcm
++  ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${library_name}.rootmap)
+ 
+ #-------------------------------------------------------------------------------
+ # Always use '@rpath' in install names of libraries.
+--- spack-src/cmake/Geant3BuildLibrary.cmake
++++ spack-src/cmake/Geant3BuildLibrary.cmake
+@@ -38,14 +38,14 @@
+ #
+ ROOT_GENERATE_DICTIONARY(
+   ${library_name}_dict
+-  ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/TCallf77.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/TG3Application.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/TGeant3f77.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/TGeant3gu.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/TGeant3.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/TGeant3TGeo.h
++  TCallf77.h
++  TG3Application.h
++  TGeant3f77.h
++  TGeant3gu.h
++  TGeant3.h
++  TGeant3TGeo.h
+   MODULE ${library_name}
+-  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/TGeant3/geant3LinkDef.h)
++  LINKDEF TGeant3/geant3LinkDef.h)
+ 
+ # Files produced by the dictionary generation
+ SET(root_dict
+--- spack-src/cmake/Geant3BuildLibrary.cmake
++++ spack-src/cmake/Geant3BuildLibrary.cmake
+@@ -45,6 +45,9 @@
+   TGeant3.h
+   TGeant3TGeo.h
+   MODULE ${library_name}
++  OPTIONS "-I${CMAKE_INSTALL_PREFIX}/include/TGeant3"
++    -excludePath "${CMAKE_CURRENT_BINARY_DIR}"
++    -excludePath "${PROJECT_SOURCE_DIR}"
+   LINKDEF TGeant3/geant3LinkDef.h)
+ 
+ # Files produced by the dictionary generation

--- a/packages/geant3/package.py
+++ b/packages/geant3/package.py
@@ -22,12 +22,11 @@ class Geant3(CMakePackage):
             description='CMake build type',
             values=('Nightly'))
 
-    # FIXME: Add dependencies if required.
-    depends_on('cmake', type='build')
     depends_on('root')
     depends_on('vmc', when='@v3-0_fairsoft:')
 
     patch('gcalor_stringsize.patch', level=0)
+    patch('dict_fixes_30.patch', when='@v3-0_fairsoft')
 
     def cmake_args(self):
         spec = self.spec

--- a/packages/geant4_vmc/dict_fixes_501.patch
+++ b/packages/geant4_vmc/dict_fixes_501.patch
@@ -1,0 +1,28 @@
+--- spack-src/source/CMakeLists.txt
++++ spack-src/source/CMakeLists.txt
+@@ -128,10 +128,10 @@
+ #
+ ROOT_GENERATE_DICTIONARY(
+   ${library_name}_dict
+-  ${CMAKE_CURRENT_SOURCE_DIR}/run/include/TG4RunConfiguration.h
+-  ${CMAKE_CURRENT_SOURCE_DIR}/run/include/TGeant4.h
++  TG4RunConfiguration.h
++  TGeant4.h
+   MODULE ${library_name}
+-  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/${library_name}LinkDef.h)
++  LINKDEF ${library_name}LinkDef.h)
+ 
+ # Files produced by the dictionary generation
+ SET(root_dict
+--- spack-src/source/CMakeLists.txt
++++ spack-src/source/CMakeLists.txt
+@@ -131,6 +131,9 @@
+   TG4RunConfiguration.h
+   TGeant4.h
+   MODULE ${library_name}
++  OPTIONS "-I${CMAKE_INSTALL_PREFIX}/include/${library_name}"
++    -excludePath "${CMAKE_CURRENT_BINARY_DIR}"
++    -excludePath "${PROJECT_SOURCE_DIR}"
+   LINKDEF ${library_name}LinkDef.h)
+ 
+ # Files produced by the dictionary generation

--- a/packages/geant4_vmc/package.py
+++ b/packages/geant4_vmc/package.py
@@ -22,6 +22,8 @@ class Geant4Vmc(CMakePackage):
     depends_on('vgm')
     depends_on('vmc', when='@5-0:')
 
+    patch('dict_fixes_501.patch', when='@5-0-p1')
+
     def cmake_args(self):
         spec = self.spec
         options = []

--- a/packages/geant4_vmc/package.py
+++ b/packages/geant4_vmc/package.py
@@ -9,16 +9,14 @@ from spack import *
 class Geant4Vmc(CMakePackage):
     """Geant4 VMC implements the Virtual Monte Carlo (VMC) for Geant4"""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://github.com/vmc-project/geant4_vmc"
     url = "https://github.com/vmc-project/geant4_vmc/archive/v3-6.tar.gz"
 
+    version('5-0-p1', sha256='b66cbf86a96b6efe1643753a7606b1c4ebb9d45cca9f6b8e933762920f32831f')
     version('3-6', '01507945dfcc21827628d0eb6b233931')
     version('4-0-p1', 'd7e88a3ef11ea62bec314b5f251c91b1')
     version('5-0', sha256='9a3820ea4b68b5a0697c340bbbc0972b9c8e4205ceecdd87258a9bdfd249cd8b')
 
-    # FIXME: Add dependencies if required.
-    depends_on('cmake', type='build')
     depends_on('root')
     depends_on('geant4')
     depends_on('vgm')

--- a/packages/pythia6/package.py
+++ b/packages/pythia6/package.py
@@ -50,3 +50,7 @@ class Pythia6(CMakePackage):
 
     version('428-alice1', '8751dda1c4b5f137817876ea0d4b8a5b')
 
+    def cmake_args(self):
+        args=[]
+        args.append('-DCMAKE_MACOSX_RPATH=ON')
+        return args


### PR DESCRIPTION
I have started to enable the testsuite for fairroot@develop because there we can control things much better (than with already released things).

First things first:
* This upgrades geant4_vmc from 5-0 to 5-0-p1. This version bump contains important things to get the testsuite going (dictionary related, as always), BUT it contains other changes, that I can't judge on.
  See: https://github.com/vmc-project/geant4_vmc/blob/v5-0-p1/history
  See: https://github.com/vmc-project/geant4_vmc/compare/v5-0...v5-0-p1

All the remaining changes are:
* Fixup the whole dictionary business for geant3 and geant4_vmc
* Let fairroot find the Pythia8 data directory
* Fix shared library generation for pythia6 on macos