### PR TITLE
Get the FairRoot 18.4.0 Release going

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,21 +66,21 @@ function(fs_test_env)
   fs_test_props(env.${ARGS_NAME})
 endfunction()
 
-fs_test_simple(NAME openssl SPEC openssl)
-fs_test_simple(NAME bzip2 SPEC bzip2)
+fs_test_simple(NAME cmake       SPEC cmake)
 fs_test_simple(NAME grpc SPEC grpc)
 fs_test_simple(NAME flatbuffers SPEC flatbuffers)
-fs_test_simple(NAME odc SPEC odc)
 fs_test_env(NAME fairlogger ENVFILE test/env/fairlogger.yaml)
 fs_test_env(NAME dds        ENVFILE test/env/dds.yaml)
 fs_test_env(NAME fairmq     ENVFILE test/env/fairmq.yaml)
+fs_test_simple(NAME odc         SPEC odc)
 
+fs_test_env(NAME dev.threads_nox_noopengl ENVFILE env/dev/sim_threads_no-x_no-opengl.yaml)
 fs_test_env(NAME dev.threads              ENVFILE env/dev/sim_threads.yaml)
 fs_test_env(NAME dev.nothreads            ENVFILE env/dev/sim_no-threads.yaml)
-fs_test_env(NAME dev.threads_nox_noopengl ENVFILE env/dev/sim_threads_no-x_no-opengl.yaml)
 
 fs_test_env(NAME jun19.threads   ENVFILE env/jun19/sim_threads.yaml)
 fs_test_env(NAME jun19.nothreads ENVFILE env/jun19/sim_no-threads.yaml)
+fs_test_env(NAME jun19.fairroot184 ENVFILE env/dev/jun19_fairroot-18.4.yaml)
 
 fs_test_env(NAME r3broot ENVFILE env/dev/r3broot.yaml)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
           ]) { spec, label, jobsh ->
             sh """
               echo "*** Submitting at: \$(date -R)"
-              srun -p main -c 64 -n 1 -t 300 --job-name="alfaci-${label}" bash ${jobsh}
+              srun -p main -c 64 -n 1 -t 400 --job-name="${label}" bash ${jobsh}
             """
           }
           def macos_jobs = jobMatrix('macos', ctestcmd, [

--- a/env/dev/jun19_fairroot-18.4.yaml
+++ b/env/dev/jun19_fairroot-18.4.yaml
@@ -1,0 +1,26 @@
+spack:
+  definitions:
+    - when: platform == 'linux'
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+    - when: platform == 'darwin'
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+  specs:
+    - pcre+jit
+    - python@2.7.16
+    - py-numpy@1.16.5
+    - googletest@1.8.1
+    - boost@1.68.0
+    - fairlogger@1.4.0
+    - dds@2.4
+    - fairmq@1.4.3
+    - pythia6@428-alice1
+    - hepmc@2.06.09 length=CM momentum=GEV
+    - pythia8@8240
+    - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
+    - $root
+    - geant3@v2-7_fairsoft
+    - vgm@4-5
+    - geant4_vmc@4-0-p1
+    - fairroot@18.4.0+sim+examples
+  concretization: together
+  view: false

--- a/env/dev/sim_no-threads.yaml
+++ b/env/dev/sim_no-threads.yaml
@@ -15,6 +15,6 @@ spack:
     - geant3@v3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0
-    - fairroot@develop+sim+examples
+    - fairroot@18.4.0+sim+examples
   concretization: together
   view: false

--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -15,6 +15,6 @@ spack:
     - geant3@v3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0
-    - fairroot@develop+sim+examples
+    - fairroot@18.4.0+sim+examples
   concretization: together
   view: false

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -15,6 +15,6 @@ spack:
     - geant3@v3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0
-    - fairroot@develop+sim+examples
+    - fairroot@18.4.0+sim+examples
   concretization: together
   view: false

--- a/packages/fairroot/package.py
+++ b/packages/fairroot/package.py
@@ -20,6 +20,7 @@ class Fairroot(CMakePackage):
     # Development versions
     version('develop', branch='dev')
 
+    version('18.4.0', branch='RC_v18.4.0')
     version('18.2.1', '06a5b3b2c5445f7342464061cccbe7bc')
     version('18.0.6', '822902c2fc879eab82fca47eccb14259')
 
@@ -46,7 +47,7 @@ class Fairroot(CMakePackage):
     # Dependencies for dev version
     depends_on('boost@1.68.0: cxxstd=11 +container')
 
-    depends_on('vmc', when='@develop')
+    depends_on('vmc', when='@18.4: ^root@6.18:')
 
     depends_on('geant4', when="+sim")
 
@@ -67,7 +68,7 @@ class Fairroot(CMakePackage):
     patch('CMake.patch', level=0, when="@18.0.6")
     patch('cmake_utf8.patch', when='@18.2.1')
     patch('fairlogger_incdir.patch', level=0, when='@18.2.1')
-    patch('link_against_flatbuffers_shared.patch', when="@develop")
+    patch('link_against_flatbuffers_shared.patch', when="@18.4:")
 
     def setup_environment(self, spack_env, run_env):
         stdversion=('-std=c++%s' % self.spec.variants['cxxstd'].value)


### PR DESCRIPTION
Major points:
* Add the RC_v18.4.0 branch as `version('18.4.0')`
* Add test environment for FairRoot 18.4 on jun19

Also some small CI bits.