### PR TITLE
CI: Git timeout, copy source tree

### DIFF
--- a/test/buildcleanup.sh
+++ b/test/buildcleanup.sh
@@ -5,7 +5,8 @@
 installedMB="$(cd $HOME/install-tree && du -ms . | sed -e 's/[	 ].*$//')"
 rm -rf "$HOME/install-tree"
 
-stageKB="$(cd $HOME/stage && du -ks . | sed -e 's/[	 ].*$//')"
+# stageKB="$(cd $HOME/stage && du -ks . | sed -e 's/[	 ].*$//')"
+(cd "$HOME" && du -sh stage)
 (cd "$HOME" && tar -cjf "stage.tar.bz2" stage) \
 	&& mv "$HOME/stage.tar.bz2" "$CMAKE_BINARY_DIR/" \
 	&& ls -l "$CMAKE_BINARY_DIR/stage.tar.bz2" \
@@ -13,4 +14,4 @@ stageKB="$(cd $HOME/stage && du -ks . | sed -e 's/[	 ].*$//')"
 
 echo ""
 echo "<DartMeasurement name=\"installedMB\" type=\"numeric/double\">$installedMB</DartMeasurement>"
-echo "<DartMeasurement name=\"stageKB\" type=\"numeric/double\">$stageKB</DartMeasurement>"
+# echo "<DartMeasurement name=\"stageKB\" type=\"numeric/double\">$stageKB</DartMeasurement>"

--- a/test/jenkins_agent_lxbk0595.def
+++ b/test/jenkins_agent_lxbk0595.def
@@ -15,7 +15,16 @@ From: centos:7.6.1810
     yum -y install git2u
 
 %startscript
-    java -jar /opt/agent.jar -jnlpUrl https://alfa-ci.gsi.de/computer/virgo/slave-agent.jnlp -secret REPLACEMEWITHREALSECRET -workDir "/lustre/rz/alfaci" > /tmp/alfaci/agent.log 2>&1
+    SECRET=REPLACEMEWITHREALSECRET
+    JAVA_ARGS="-Dorg.jenkinsci.plugins.gitclient.Git.timeOut=60"
+    JAVA_ARGS="$JAVA_ARGS -Dorg.jenkinsci.plugins.gitclient.CliGitAPIImpl.TIMEOUT=60"
+
+    if [ -r "$HOME/.config/jenkins_agent/$(hostname)/config.sh" ]
+    then
+        source "$HOME/.config/jenkins_agent/$(hostname)/config.sh"
+    fi
+
+    java $JAVA_ARGS -jar /opt/agent.jar -jnlpUrl https://alfa-ci.gsi.de/computer/virgo/slave-agent.jnlp -secret "$SECRET" -workDir "/lustre/rz/alfaci" > /tmp/alfaci/agent.log 2>&1
 
 %environment
     export https_proxy=http://proxy-ib2.gsi.de:3128/


### PR DESCRIPTION
* Set git Timeout to 60 mins in virgo Container
  For various reasons, some git operations might take longer than the default 10 minutes. Set this to 60 minutes.
  Also make the jenkins agent config more flexible by sourcing a config file from the home directory.
* Copy Source Directory to Temporary Directory
  A lot of work is being done still in the source directory of spack itself (especially python bytecode cache). By copying the FairSoft source tree to the temporary directory, we can do this on fast local storage.
  While at it, remove the complete temporary directory after the whole build is done. That way, we're not leaking stuff in /tmp.
* Misc stuff