### PR TITLE
root: Use xrootd from spack; Misc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,12 +51,19 @@ pipeline {
         script {
           def ctestcmd = "ctest -VV -S FairSoft_test.cmake"
           def specs_list = [
-            [os: 'Fedora30', container: 'fedora.30.sif'],
-            [os: 'Ubuntu-18.04-LTS', container: 'ubuntu.18.04.sif'],
+            [os: 'Fedora30',         container: 'fedora.30.sif',    for_pr: true],
+            [os: 'Ubuntu-18.04-LTS', container: 'ubuntu.18.04.sif', for_pr: true],
             [os: 'GSI-Debian-8', container: 'gsi-debian-8.sif'],
             [os: 'openSUSE-15.0', container: 'opensuse.15.0.sif'],
             [os: 'openSUSE-15.2', container: 'opensuse.15.2.sif'],
           ]
+
+          if (env.CHANGE_ID != null) {
+              specs_list = specs_list.findAll {
+                  elmt -> elmt.getOrDefault("for_pr", false)
+              }
+          }
+
           def linux_jobs = jobMatrix('slurm',
             ctestcmd + " -DUSE_TEMPDIR:BOOL=ON", specs_list
           ) { spec, label, jobsh ->

--- a/env/dev/jun19_fairroot-18.4.yaml
+++ b/env/dev/jun19_fairroot-18.4.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+xrootd ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+xrootd+aqua]
   specs:
     - pcre+jit
     - python@2.7.16

--- a/env/dev/r3broot.yaml
+++ b/env/dev/r3broot.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+xrootd ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+xrootd+aqua]
   specs:
     - pcre+jit
     - python@2.7.16

--- a/env/dev/sim_no-threads.yaml
+++ b/env/dev/sim_no-threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva+xrootd ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva+xrootd+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1

--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva+xrootd ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt+python+tmva+xrootd+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt~x~opengl+python+tmva]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt~x~opengl+python+tmva+xrootd]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt~x~opengl+python+tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+pythia6+pythia8+vc~vdt~x~opengl+python+tmva+xrootd+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1

--- a/env/jun19/sim_no-threads.yaml
+++ b/env/jun19/sim_no-threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+xrootd ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+xrootd+aqua]
   specs:
     - pcre+jit
     - python@2.7.16

--- a/env/jun19/sim_threads.yaml
+++ b/env/jun19/sim_threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+xrootd ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+aqua]
+      root: [root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+xrootd+aqua]
   specs:
     - pcre+jit
     - python@2.7.16

--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -68,7 +68,6 @@ class Root(CMakePackage):
     patch('graf3d_gl_6.18.patch', level=0, when='@6.18:')
     patch('graf2d.patch', level=0)
     patch('external_zlib.patch', level=0, when='@6.12.06')
-    patch('root6_16_xrootd.patch', level=0, when='@6.16.00')
 
     if sys.platform == 'darwin':
         # Resolve non-standard use of uint, _cf_
@@ -182,7 +181,7 @@ class Root(CMakePackage):
     variant('xml', default=True,
         description='Enable XML parser interface')
     variant('xrootd', default=False,
-        description='Build xrootd file server and its client')
+            description='Build xrootd file server and its client')
 
     # ###################### Compiler variants ########################
 
@@ -331,7 +330,7 @@ class Root(CMakePackage):
             '-Dbuiltin_vc:BOOL=OFF',
             '-Dbuiltin_vdt:BOOL=OFF',
             '-Dbuiltin_veccore:BOOL=OFF',
-            '-Dbuiltin_xrootd:BOOL=ON',
+            '-Dbuiltin_xrootd:BOOL=OFF',
             '-Dbuiltin_zlib:BOOL=OFF'
         ]
 

--- a/packages/xrootd/package.py
+++ b/packages/xrootd/package.py
@@ -1,0 +1,103 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Xrootd(CMakePackage):
+    """The XROOTD project aims at giving high performance, scalable fault
+       tolerant access to data repositories of many kinds."""
+    homepage = "http://xrootd.org"
+    url      = "http://xrootd.org/download/v4.6.0/xrootd-4.6.0.tar.gz"
+
+    version('4.10.0', sha256='f07f85e27d72e9e8ff124173c7b53619aed8fcd36f9d6234c33f8f7fd511995b')
+    version('4.8.5',  sha256='42e4d2cc6f8b442135f09bcc12c7be38b1a0c623a005cb5e69ff3d27997bdf73')
+    version('4.8.4',  sha256='f148d55b16525567c0f893edf9bb2975f7c09f87f0599463e19e1b456a9d95ba')
+    version('4.8.3',  sha256='9cd30a343758b8f50aea4916fa7bd37de3c37c5b670fe059ae77a8b2bbabf299')
+    version('4.8.2',  sha256='8f28ec53e799d4aa55bd0cc4ab278d9762e0e57ac40a4b02af7fc53dcd1bef39')
+    version('4.8.1',  sha256='edee2673d941daf7a6e5c963d339d4a69b4db5c4b6f77b4548b3129b42198029')
+    version('4.8.0',  sha256='0b59ada295341902ca01e9d23e29780fb8df99a6d2bd1c2d654e9bb70c877ad8')
+    version('4.7.1',  sha256='90ddc7042f05667045b06e02c8d9c2064c55d9a26c02c50886254b8df85fc577')
+    version('4.7.0',  sha256='6cc69d9a3694e8dcf2392e9c3b518bd2497a89b3a9f25ffaec62efa52170349b')
+    version('4.6.1',  sha256='0261ce760e8788f85d68918d7702ae30ec677a8f331dae14adc979b4cc7badf5')
+    version('4.6.0',  sha256='b50f7c64ed2a4aead987de3fdf6fce7ee082407ba9297b6851cd917db72edd1d')
+    version('4.5.0',  sha256='27a8e4ef1e6bb6bfe076fef50afe474870edd198699d43359ef01de2f446c670')
+    version('4.4.1',  sha256='3c295dbf750de086c04befc0d3c7045fd3976611c2e75987c1477baca37eb549')
+    version('4.4.0',  sha256='f066e7488390c0bc50938d23f6582fb154466204209ca92681f0aa06340e77c8')
+    version('4.3.0',  sha256='d34865772d975b5d58ad80bb05312bf49aaf124d5431e54dc8618c05a0870e3c')
+
+    variant('http', default=True,
+            description='Build with HTTP support')
+
+    variant('python', default=False,
+            description='Build pyxroot Python extension')
+
+    variant('readline', default=True,
+            description='Use readline')
+
+    variant('cxxstd',
+            default='11',
+            values=('98', '11', '14', '17'),
+            multi=False,
+            description='Use the specified C++ standard when building.')
+
+    conflicts('cxxstd=98', when='@4.7.0:')
+
+    depends_on('bzip2')
+    depends_on('cmake@2.6:', type='build')
+    depends_on('libxml2', when='+http')
+    depends_on('openssl')
+    depends_on('python', when='+python')
+    depends_on('readline', when='+readline')
+    depends_on('xz')
+    depends_on('zlib')
+
+    extends('python', when='+python')
+    patch('python-support.patch', level=1, when='@:4.8.99+python')
+
+    def patch(self):
+        """Remove hardcoded -std=c++0x flag
+        """
+        if self.spec.satisfies('@4.7.0:'):
+            filter_file(r'\-std=c\+\+0x', r'', 'cmake/XRootDOSDefs.cmake')
+
+    def cmake_args(self):
+        spec = self.spec
+        options = [
+            '-DENABLE_HTTP:BOOL={0}'.
+            format('ON' if '+http' in spec else 'OFF'),
+            '-DENABLE_PYTHON:BOOL={0}'.
+            format('ON' if '+python' in spec else 'OFF'),
+            '-DENABLE_READLINE:BOOL={0}'.
+            format('ON' if '+readline' in spec else 'OFF'),
+            '-DENABLE_CEPH:BOOL=OFF'
+        ]
+        # see https://github.com/spack/spack/pull/11581
+        if '+python' in self.spec:
+            options.append('-DPYTHON_EXECUTABLE=%s' %
+                           spec['python'].command.path)
+
+        return options
+
+    def setup_build_environment(self, env):
+        cxxstdflag = ''
+        if self.spec.variants['cxxstd'].value == '98':
+            cxxstdflag = self.compiler.cxx98_flag
+        elif self.spec.variants['cxxstd'].value == '11':
+            cxxstdflag = self.compiler.cxx11_flag
+        elif self.spec.variants['cxxstd'].value == '14':
+            cxxstdflag = self.compiler.cxx14_flag
+        elif self.spec.variants['cxxstd'].value == '17':
+            cxxstdflag = self.compiler.cxx17_flag
+        else:
+            # The user has selected a (new?) legal value that we've
+            # forgotten to deal with here.
+            tty.die(
+                "INTERNAL ERROR: cannot accommodate unexpected variant ",
+                "cxxstd={0}".format(self.spec.variants['cxxstd'].value))
+
+        if cxxstdflag:
+            env.append_flags('CXXFLAGS', cxxstdflag)

--- a/packages/xrootd/python-support.patch
+++ b/packages/xrootd/python-support.patch
@@ -1,0 +1,30 @@
+diff -Naur xrootd-4.8.0/bindings/python/setup.py.in xrootd-4.8.0/bindings/python/setup.py.in
+--- xrootd-4.8.0/bindings/python/setup.py.in	2017-12-13 11:28:52.000000000 -0600
++++ xrootd-4.8.0/bindings/python/setup.py.in	2017-12-21 17:47:51.378701139 -0600
+@@ -16,6 +16,13 @@
+ py_cflags = cfg_vars["PY_CFLAGS"]
+ cfg_vars["PY_CFLAGS"] = " ".join( flag for flag in py_cflags.split() if flag not in ['-Wstrict-prototypes' ${CLANG_PROHIBITED} ] )
+ 
++ccl=cfg_vars["CC"].split()
++ccl[0]="${CMAKE_C_COMPILER}"
++cfg_vars["CC"] = " ".join(ccl)
++cxxl=cfg_vars["CXX"].split()
++cxxl[0]="${CMAKE_CXX_COMPILER}"
++cfg_vars["CXX"] = " ".join(cxxl)
++cfg_vars["PY_CXXFLAGS"] = "${CMAKE_CXX_FLAGS}"
+ 
+ sources = list()
+ depends = list()
+diff -Naur xrootd-4.8.0/cmake/XRootDFindLibs.cmake xrootd-4.8.0/cmake/XRootDFindLibs.cmake
+--- xrootd-4.8.0/cmake/XRootDFindLibs.cmake	2017-12-13 11:28:52.000000000 -0600
++++ xrootd-4.8.0/cmake/XRootDFindLibs.cmake	2017-12-21 17:47:51.379701131 -0600
+@@ -85,8 +85,8 @@
+ endif()
+ 
+ if( ENABLE_PYTHON AND (Linux OR APPLE) )
+-  find_package( PythonLibs ${XRD_PYTHON_REQ_VERSION} )
+   find_package( PythonInterp ${XRD_PYTHON_REQ_VERSION} )
++  find_package( PythonLibs ${XRD_PYTHON_REQ_VERSION} )
+   if( PYTHONINTERP_FOUND AND PYTHONLIBS_FOUND )
+     set( BUILD_PYTHON TRUE )
+     set( PYTHON_FOUND TRUE )


### PR DESCRIPTION
root used to build an internal xrootd. It used to download it on its own. This download sometimes fails and leaves the whole root build failing. So switch to spack's xrootd instead.

We haven't build root with xrootd, but some experiments actually need it. So build root with (external) xrootd.

Misc/CI: Only use a small subset of the containers during PR (like this one). Use the full set on branch builds (after being merged into the branch, for example).