### PR TITLE
CI: Add Debian-10 container; Start listing changed files; Setup Fixtures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,21 @@ function(fs_test_env)
   fs_test_props(env.${ARGS_NAME})
 endfunction()
 
+
+# Test setup
+# ----------
+
+add_test(NAME test.start
+         COMMAND test/buildstart.sh
+         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+fs_test_props_base(test.start)
+set_property(TEST test.start APPEND PROPERTY
+             FIXTURES_SETUP fixture.main)
+
+
+# Main tests
+# ----------
+
 fs_test_simple(NAME cmake       SPEC cmake)
 fs_test_simple(NAME grpc SPEC grpc)
 fs_test_simple(NAME flatbuffers SPEC flatbuffers)
@@ -83,6 +98,10 @@ fs_test_env(NAME jun19.nothreads ENVFILE env/jun19/sim_no-threads.yaml)
 fs_test_env(NAME jun19.fairroot184 ENVFILE env/dev/jun19_fairroot-18.4.yaml)
 
 fs_test_env(NAME r3broot ENVFILE env/dev/r3broot.yaml)
+
+
+# Test cleanup
+# ------------
 
 add_test(NAME test.cleanup
          COMMAND test/buildcleanup.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ pipeline {
           def specs_list = [
             [os: 'Fedora30',         container: 'fedora.30.sif',    for_pr: true],
             [os: 'Ubuntu-18.04-LTS', container: 'ubuntu.18.04.sif', for_pr: true],
+            [os: 'Debian-10',        container: 'debian.10.sif'],
             [os: 'GSI-Debian-8', container: 'gsi-debian-8.sif'],
             [os: 'openSUSE-15.0', container: 'opensuse.15.0.sif'],
             [os: 'openSUSE-15.2', container: 'opensuse.15.2.sif'],

--- a/test/buildstart.sh
+++ b/test/buildstart.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+echo "*** Setting things up:"
+
+. test/buildsetup.sh
+
+
+function handle_gitdifflist() {
+	while read -d "" filename
+	do
+		echo "*** Looking at '$filename'"
+		case "$filename" in
+			packages/*)
+				pkg="${filename#packages/}"
+				pkg="${pkg%%/*}"
+				echo "    Would uninstall '$pkg'"
+				;;
+			spack)
+				echo "    spack was changed, needing to wipe everything"
+				;;
+			env/*.yaml)
+				echo "    Ignoring"
+				;;
+			*)
+				echo "    Don't know about this one"
+				;;
+		esac
+	done
+}
+
+
+if [ -n "$CHANGE_ID" -a -n "$CHANGE_TARGET" ]
+then
+	echo "*** Trying to list changed files (origin/$CHANGE_TARGET -> HEAD)"
+	git diff --name-only "origin/$CHANGE_TARGET" HEAD --
+	echo "*** Analyzing list and acting"
+	git diff --name-only -z "origin/$CHANGE_TARGET" HEAD -- \
+		| handle_gitdifflist
+fi

--- a/test/container/debian.10.def
+++ b/test/container/debian.10.def
@@ -1,7 +1,14 @@
+# Rebuild:
+#   singularity build -f -F debian.10.sif debian.10.def
+
 Bootstrap: docker
 From: debian:10
 
 %post
     apt-get update
     apt-get -y upgrade
-    apt-get -y install cmake cmake-data g++ gcc gfortran debianutils build-essential make patch sed libx11-dev libxft-dev libxext-dev libxpm-dev libxmu-dev libglu1-mesa-dev libgl1-mesa-dev libncurses5-dev curl libcurl4-openssl-dev bzip2 libbz2-dev gzip unzip tar subversion git xutils-dev flex bison lsb-release python-dev libc6-dev-i386 libxml2-dev wget libssl-dev libkrb5-dev automake autoconf libtool
+    apt-get -y --no-install-recommends install sed curl ca-certificates wget xz-utils bzip2 gzip unzip tar
+    apt-get -y --no-install-recommends install python3 g++ gcc gfortran make patch git
+    # Things for our testing system:
+    apt-get -y --no-install-recommends install cmake hostname lsb-release
+    apt-get -y clean


### PR DESCRIPTION
#### Well, added yet another Container

#### Start listing changed files
When we want to reuse old builds (install-tree), we need to know, which packages changed. For this, we need to know, which files changed.

Let's start by listing the changed files.

####  Setup Fixtures
When we're going to run tests in parallel, then the setup of spack needs to be done in a concrete place. Start with a dummy buildstart.sh for this. We can put more in here. For now the changed files listing is here.