### PR TITLE
fairmq: Use Bundled gtest

### DIFF
--- a/packages/fairmq/package.py
+++ b/packages/fairmq/package.py
@@ -45,6 +45,7 @@ class Fairmq(CMakePackage):
     conflicts('cxxstd=11', when='@1.4.11:')
 
     patch('fix_find_dds.patch', when='@1.4.0:1.4.4')
+    patch('use_bundled_gtest_149.patch', when='@1.4.9:1.4.16')
 
     depends_on('googletest@1.7:', when='@:1.4.8')
     depends_on('boost@1.64: +container+program_options+thread+system+filesystem+regex+date_time', when='@1.3')

--- a/packages/fairmq/use_bundled_gtest_149.patch
+++ b/packages/fairmq/use_bundled_gtest_149.patch
@@ -1,0 +1,32 @@
+commit b32e04db6051024ce0439128c89cff153281cdec
+Author: Dennis Klein <d.klein@gsi.de>
+Date:   Tue May 19 10:23:15 2020 +0200
+
+    Do not search external GTest by default
+    
+    Can be overridden by -DUSE_EXTERNAL_GTEST=ON.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e1279fd4..6661b2b5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,6 +51,8 @@ fairmq_build_option(BUILD_DOCS              "Build FairMQ documentation."
+                                              DEFAULT OFF)
+ fairmq_build_option(FAST_BUILD              "Fast production build. Not recommended for development."
+                                              DEFAULT OFF)
++fairmq_build_option(USE_EXTERNAL_GTEST      "Do not use bundled GTest. Not recommended."
++                                             DEFAULT OFF)
+ ################################################################################
+ 
+ 
+@@ -160,7 +160,9 @@
+ endif()
+ 
+ if(BUILD_TESTING)
+-  find_package2(PRIVATE GTest VERSION 1.7.0)
++  if(USE_EXTERNAL_GTEST)
++    find_package2(PRIVATE GTest VERSION 1.7.0)
++  endif()
+   if(NOT GTest_FOUND)
+     build_bundled(GTest extern/googletest)
+     find_package2(PRIVATE GTest REQUIRED)


### PR DESCRIPTION
fairmq/dev decided to default to using its bundled gtest instead of any pre-installed one.

Backport this to previous versions starting with 1.4.9.

1.4.8 has issues with its internal submodule update. So it stays like it is.

fixes #250