### PR TITLE
geant3: More Cleanup, Version Renumbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ dds@2.4
 fairlogger@1.4.0
 fairmq@1.4.3
 fairroot@18.2.1 +sim
-geant3@v2-7_fairsoft
+geant3@2-7_fairsoft
 geant4@10.05.p01 ~clhep~data~motif~opengl~qt+threads~vecgeom~x11
 geant4_vmc@4-0-p1
 googletest@1.8.1
@@ -177,7 +177,7 @@ dds@2.4
 fairlogger@1.4.0
 fairmq@1.4.3
 fairroot@18.2.1 +sim
-geant3@v2-7_fairsoft
+geant3@2-7_fairsoft
 geant4@10.05.p01 ~clhep~data~motif~opengl~qt+threads~vecgeom~x11
 geant4_vmc@4-0-p1
 googletest@1.8.1
@@ -197,7 +197,7 @@ cmake@3.13.4       g4radioactivedecay@5.3   libedit@3.1-20170329  libxrender@0.9
 davix@0.6.8        g4realsurface@2.1.1      libevent@2.1.8        llvm@9.0.0          tar@1.32
 dds@2.4            g4saiddata@2.0           libice@1.0.9          lz4@1.9.2           unuran@1.8.1
 expat@2.2.9        g4tendl@1.3.2            libiconv@1.16         mesa@18.3.6         vc@1.4.1
-fairlogger@1.4.0   geant3@v2-7_fairsoft     libpciaccess@0.13.5   mesa-glu@9.0.0      vgm@4-5
+fairlogger@1.4.0   geant3@2-7_fairsoft      libpciaccess@0.13.5   mesa-glu@9.0.0      vgm@4-5
 fairmq@1.4.3       geant4@10.05.p01         libpng@1.6.37         msgpack-c@3.1.1     xerces-c@3.2.2
 fairroot@18.2.1    geant4-data@10.05        libpthread-stubs@0.4  nanomsg@1.1.5       xextproto@7.3.0
 font-util@1.3.2    geant4_vmc@4-0-p1        libsm@1.2.2           ncurses@6.1         xproto@7.0.31

--- a/env/dev/jun19_fairroot-18.4.yaml
+++ b/env/dev/jun19_fairroot-18.4.yaml
@@ -18,7 +18,7 @@ spack:
     - pythia8@8240
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root
-    - geant3@v2-7_fairsoft
+    - geant3@2-7_fairsoft
     - vgm@4-5
     - geant4_vmc@4-0-p1
     - fairroot@18.4.0+sim+examples

--- a/env/dev/r3broot.yaml
+++ b/env/dev/r3broot.yaml
@@ -18,7 +18,7 @@ spack:
     - pythia8@8240
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep~threads
     - $root
-    - geant3@v2-7_fairsoft
+    - geant3@2-7_fairsoft
     - vgm@4-5
     - geant4_vmc@4-0-p1
     - fairroot@18.2.1+sim

--- a/env/dev/sim_no-threads.yaml
+++ b/env/dev/sim_no-threads.yaml
@@ -12,7 +12,7 @@ spack:
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep~threads
     - $root
     - vmc@1-0-p1
-    - geant3@v3-0_fairsoft
+    - geant3@3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0-p1
     - fairroot@18.4.0+sim+examples

--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -12,7 +12,7 @@ spack:
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root
     - vmc@1-0-p1
-    - geant3@v3-0_fairsoft
+    - geant3@3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0-p1
     - fairroot@18.4.0+sim+examples

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -12,7 +12,7 @@ spack:
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root
     - vmc@1-0-p1
-    - geant3@v3-0_fairsoft
+    - geant3@3-0_fairsoft
     - vgm@4-7
     - geant4_vmc@5-0-p1
     - fairroot@18.4.0+sim+examples

--- a/env/jun19/sim_no-threads.yaml
+++ b/env/jun19/sim_no-threads.yaml
@@ -18,7 +18,7 @@ spack:
     - pythia8@8240
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep~threads
     - $root
-    - geant3@v2-7_fairsoft
+    - geant3@2-7_fairsoft
     - vgm@4-5
     - geant4_vmc@4-0-p1
     - fairroot@18.2.1+sim+examples

--- a/env/jun19/sim_threads.yaml
+++ b/env/jun19/sim_threads.yaml
@@ -18,7 +18,7 @@ spack:
     - pythia8@8240
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root
-    - geant3@v2-7_fairsoft
+    - geant3@2-7_fairsoft
     - vgm@4-5
     - geant4_vmc@4-0-p1
     - fairroot@18.2.1+sim+examples

--- a/packages/geant3/package.py
+++ b/packages/geant3/package.py
@@ -9,21 +9,19 @@ from spack import *
 class Geant3(CMakePackage):
     """Simulation software using Monte Carlo methods to describe how particles pass through matter.."""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://root.cern.ch/vmc"
-
     git      = "https://github.com/FairRootGroup/geant3.git"
 
-    version('v2-5-gcc8', tag='v2-5-gcc8')
-    version('v2-7_fairsoft', tag='v2-7_fairsoft')
-    version('v3-0_fairsoft', tag='v3-0_fairsoft')
+    version('2-5-gcc8', tag='v2-5-gcc8')
+    version('2-7_fairsoft', tag='v2-7_fairsoft')
+    version('3-0_fairsoft', tag='v3-0_fairsoft')
 
     variant('build_type', default='Nightly',
             description='CMake build type',
             values=('Nightly'))
 
     depends_on('root')
-    depends_on('vmc', when='@v3-0_fairsoft:')
+    depends_on('vmc', when='@3-0_fairsoft:')
 
     patch('gcalor_stringsize.patch', level=0)
     patch('dict_fixes_30.patch', when='@v3-0_fairsoft')


### PR DESCRIPTION
More things about the geant3 recipe:

* Remove the leading "v" from the version numbers, so that they're more numeric. Also change all references appropiately.
* Remove duplicated depends_on.
* Remove unneeded comments.