### PR TITLE
pythia8: Add Patch and new Versions

### DIFF
--- a/env/dev/sim_no-threads.yaml
+++ b/env/dev/sim_no-threads.yaml
@@ -7,7 +7,7 @@ spack:
   specs:
     - pythia6@428-alice1
     - hepmc@2.06.09 length=CM momentum=GEV
-    - pythia8@8301
+    - pythia8@8302
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep~threads
     - $root
     - vmc@1-0-p1

--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -7,7 +7,7 @@ spack:
   specs:
     - pythia6@428-alice1
     - hepmc@2.06.09 length=CM momentum=GEV
-    - pythia8@8301
+    - pythia8@8302
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root
     - vmc@1-0-p1

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -7,7 +7,7 @@ spack:
   specs:
     - pythia6@428-alice1
     - hepmc@2.06.09 length=CM momentum=GEV
-    - pythia8@8301
+    - pythia8@8302
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root
     - vmc@1-0-p1

--- a/repos/fairsoft/packages/pythia8/package.py
+++ b/repos/fairsoft/packages/pythia8/package.py
@@ -22,6 +22,11 @@ class Pythia8(AutotoolsPackage):
     version('8230', sha256='332fad0ed4f12e6e0cb5755df0ae175329bc16bfaa2ae472d00994ecc99cd78d')
     version('8212', sha256='f8fb4341c7e8a8be3347eb26b00329a388ccf925313cfbdba655a08d7fd5a70e')
 
+    # Avoid sqrt of negative numbers
+    # See: https://github.com/alisw/alidist/pull/2333
+    # See: https://github.com/alisw/pythia8/commit/a854fb5c250fe7b7b17e4e43f7dcb03e63ee1364
+    patch('ropewalk_sqrt.patch', when='@8240:8244,8301:8302')
+
     depends_on('rsync', type='build')
     depends_on('hepmc@2:2.99')
 

--- a/repos/fairsoft/packages/pythia8/package.py
+++ b/repos/fairsoft/packages/pythia8/package.py
@@ -11,8 +11,10 @@ class Pythia8(AutotoolsPackage):
        i.e. for the description of collisions at high energies between elementary
        particles such as e+, e-, p and pbar in various combinations."""
 
-    homepage = "http://home.thep.lu.se/~torbjorn/Pythia.html"
+    homepage = "http://home.thep.lu.se/Pythia/"
     url      = "http://home.thep.lu.se/~torbjorn/pythia8/pythia8244.tgz"
+
+    maintainers = ['ChristianTackeGSI']
 
     version('8302', sha256='7372e4cc6f48a074e6b7bc426b040f218ec4a64b0a55e89da6af56933b5f5085')
     version('8301', sha256='51382768eb9aafb97870dca1909516422297b64ef6a6b94659259b3e4afa7f06')

--- a/repos/fairsoft/packages/pythia8/package.py
+++ b/repos/fairsoft/packages/pythia8/package.py
@@ -1,27 +1,8 @@
-##############################################################################
-# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# This file is part of Spack.
-# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
-# LLNL-CODE-647188
-#
-# For details, see https://github.com/spack/spack
-# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License (as
-# published by the Free Software Foundation) version 2.1, February 1999.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-# conditions of the GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-##############################################################################
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
 
 
@@ -31,9 +12,11 @@ class Pythia8(AutotoolsPackage):
        particles such as e+, e-, p and pbar in various combinations."""
 
     homepage = "http://home.thep.lu.se/~torbjorn/Pythia.html"
-    url      = "http://home.thep.lu.se/~torbjorn/pythia8/pythia8212.tgz"
+    url      = "http://home.thep.lu.se/~torbjorn/pythia8/pythia8244.tgz"
 
+    version('8302', sha256='7372e4cc6f48a074e6b7bc426b040f218ec4a64b0a55e89da6af56933b5f5085')
     version('8301', sha256='51382768eb9aafb97870dca1909516422297b64ef6a6b94659259b3e4afa7f06')
+    version('8244', sha256='e34880f999daf19cdd893a187123927ba77d1bf851e30f6ea9ec89591f4c92ca', preferred=True)
     version('8240', sha256='d27495d8ca7707d846f8c026ab695123c7c78c7860f04e2c002e483080418d8d')
     version('8235', sha256='e82f0d6165a8250a92e6aa62fb53201044d8d853add2fdad6d3719b28f7e8e9d')
     version('8230', sha256='332fad0ed4f12e6e0cb5755df0ae175329bc16bfaa2ae472d00994ecc99cd78d')

--- a/repos/fairsoft/packages/pythia8/package.py
+++ b/repos/fairsoft/packages/pythia8/package.py
@@ -25,6 +25,8 @@ class Pythia8(AutotoolsPackage):
     # Avoid sqrt of negative numbers
     # See: https://github.com/alisw/alidist/pull/2333
     # See: https://github.com/alisw/pythia8/commit/a854fb5c250fe7b7b17e4e43f7dcb03e63ee1364
+    # See: https://github.com/alisw/alidist/pull/2336
+    # See: https://github.com/alisw/pythia8/commit/f97ec11943af269e3b08634c03339ae4189b3bbe
     patch('ropewalk_sqrt.patch', when='@8240:8244,8301:8302')
 
     depends_on('rsync', type='build')

--- a/repos/fairsoft/packages/pythia8/ropewalk_sqrt.patch
+++ b/repos/fairsoft/packages/pythia8/ropewalk_sqrt.patch
@@ -1,3 +1,6 @@
+Modified to fix typo (mTc2 -> mTa2) by Christian Tacke
+
+
 From a854fb5c250fe7b7b17e4e43f7dcb03e63ee1364 Mon Sep 17 00:00:00 2001
 From: Roberto Preghenella <preghenella@bo.infn.it>
 Date: Sat, 27 Jun 2020 19:46:58 +0200
@@ -25,7 +28,7 @@ index e4da529..56bef3b 100644
 +  double mTc2 = pcm.pT2() + pcm.m2Calc();
 +  double mTa2 = pam.pT2() + pam.m2Calc();
 +  
-+  if (mTc2 <= 0 || mTc2 <= 0) {
++  if (mTc2 <= 0 || mTa2 <= 0) {
      infoPtr->errorMsg("Error in RopeDipole::propagateInit: Tried to"
 -      "propagate a RopeDipoleEnd with mT = 0");
 -

--- a/repos/fairsoft/packages/pythia8/ropewalk_sqrt.patch
+++ b/repos/fairsoft/packages/pythia8/ropewalk_sqrt.patch
@@ -1,0 +1,40 @@
+From a854fb5c250fe7b7b17e4e43f7dcb03e63ee1364 Mon Sep 17 00:00:00 2001
+From: Roberto Preghenella <preghenella@bo.infn.it>
+Date: Sat, 27 Jun 2020 19:46:58 +0200
+Subject: [PATCH] Patch for floating point exception in Ropewalk.cc (by
+ C.Bierlich)
+
+See discussion in JIRA
+https://alice.its.cern.ch/jira/browse/ALIROOT-8488
+---
+ src/Ropewalk.cc | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/src/Ropewalk.cc b/src/Ropewalk.cc
+index e4da529..56bef3b 100644
+--- a/src/Ropewalk.cc
++++ b/src/Ropewalk.cc
+@@ -103,12 +103,18 @@ void RopeDipole::propagateInit(double deltat) {
+   // Dipole end momenta.
+   Vec4 pcm = d1.getParticlePtr()->p();
+   Vec4 pam = d2.getParticlePtr()->p();
+-  double mTc = sqrt(pcm.pT2() + pcm.m2Calc());
+-  double mTa = sqrt(pam.pT2() + pam.m2Calc());
+-  if (mTc == 0 || mTa == 0)
++  
++  double mTc2 = pcm.pT2() + pcm.m2Calc();
++  double mTa2 = pam.pT2() + pam.m2Calc();
++  
++  if (mTc2 <= 0 || mTc2 <= 0) {
+     infoPtr->errorMsg("Error in RopeDipole::propagateInit: Tried to"
+-      "propagate a RopeDipoleEnd with mT = 0");
+-
++      "propagate a RopeDipoleEnd with mT2 <= 0");
++    return;
++  }
++  double mTc = sqrt(mTc2);
++  double mTa = sqrt(mTa2);
++  
+   // New vertices in the lab frame.
+   Vec4 newv1 = Vec4(d1.getParticlePtr()->xProd() + deltat * pcm.px() / mTc,
+                 d1.getParticlePtr()->yProd() + deltat * pcm.py() / mTc, 0, 0);


### PR DESCRIPTION
* Add patch to avoid `sqrt` of a negative numbers in `Ropewalk.cc`
  See: https://github.com/alisw/alidist/pull/2333
  See: https://github.com/alisw/pythia8/commit/a854fb5c250fe7b7b17e4e43f7dcb03e63ee1364
* Fix typo in patch
  Asked in the alisw PR: https://github.com/alisw/alidist/pull/2333#issuecomment-651054503
* Add version 8244 and 8302
  (none are yet used in any environment)

cc: @fuhlig1 