### PR TITLE
Improve Recipe Compatibility with spack Versions

### DIFF
--- a/packages/fairmq/package.py
+++ b/packages/fairmq/package.py
@@ -53,7 +53,10 @@ class Fairmq(CMakePackage):
     conflicts('^boost@1.70:', when='^cmake@:3.14')
     depends_on('fairlogger@1.2:1.5', when='@:1.4.7')
     depends_on('fairlogger@1.2:', when='@1.4.8:')
-    depends_on('zeromq@4.1.5:')
+    if Version(spack_version) >= Version('0.14'):
+        depends_on('libzmq@4.1.5:')
+    else:
+        depends_on('zeromq@4.1.5:')
     depends_on('nanomsg@1.1.5:')
     depends_on('msgpack-c@3.1:')
     depends_on('dds@2.2:2.4', when='@:1.4.9')

--- a/packages/grpc/package.py
+++ b/packages/grpc/package.py
@@ -24,7 +24,10 @@ class Grpc(CMakePackage):
     depends_on('protobuf')
     depends_on('openssl')
     depends_on('zlib')
-    depends_on('cares')
+    if Version(spack_version) >= Version('0.14'):
+        depends_on('c-ares')
+    else:
+        depends_on('cares')
     depends_on('benchmark')
     depends_on('gflags')
 


### PR DESCRIPTION
In spack 0.14.x packages were renamed.
Notably ...
* zeromq is now libzmq
* cares is now c-ares

Ussing `spack_version` one can determine the spack version that is being used to run a recipe. That way, we can utilize the correct depends_on.