### PR TITLE
CI: Increase passed test output size, Misc

### DIFF
--- a/FairSoft_test.cmake
+++ b/FairSoft_test.cmake
@@ -6,6 +6,9 @@
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
+message(STATUS " Starting CTest script : FairSoft_test.cmake")
+message(STATUS " CMake Version ........: ${CMAKE_VERSION}")
+
 if (USE_TEMPDIR)
     execute_process(COMMAND mktemp -d --tmpdir fairsoft_ctest.XXXXXX
                     OUTPUT_VARIABLE FS_TEST_WORKDIR
@@ -38,11 +41,12 @@ endif()
 
 set(CTEST_BINARY_DIRECTORY build)
 set(CTEST_TEST_TIMEOUT 10800)
+set(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 204800)
 set(CTEST_USE_LAUNCHERS ON)
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 cmake_host_system_information(RESULT fqdn QUERY FQDN)
 
-message(STATUS "Running on host: ${fqdn}")
+message(STATUS " Running on host ......: ${fqdn}")
 if ("$ENV{CTEST_SITE}" STREQUAL "")
   set(CTEST_SITE "${fqdn}")
 else()
@@ -71,8 +75,8 @@ if (NOT "$ENV{JOB_BASE_NAME}" STREQUAL "")
     set(CTEST_BUILD_NAME "$ENV{JOB_BASE_NAME} ${CTEST_BUILD_NAME}")
 endif()
 
-message(STATUS "BRANCH_NAME: $ENV{BRANCH_NAME}")
-message(STATUS "CHANGE_ID: $ENV{CHANGE_ID}")
+message(STATUS " BRANCH_NAME ..........: $ENV{BRANCH_NAME}")
+message(STATUS " CHANGE_ID ............: $ENV{CHANGE_ID}")
 set(cdash_group "Experimental")
 if (NOT "$ENV{BRANCH_NAME}" STREQUAL "")
     set(cdash_group "Continuous")
@@ -80,7 +84,7 @@ if (NOT "$ENV{BRANCH_NAME}" STREQUAL "")
         set(cdash_group "Nightly")
     endif()
 endif()
-message(STATUS "cdash_group: ${cdash_group}")
+message(STATUS " cdash_group ..........: ${cdash_group}")
 
 
 # The cache contains the name of the source directory.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,8 @@ def jobMatrix(String node_type, String ctestcmd, List specs, Closure callback) {
           if (node_type == 'slurm') {
             sh """
               echo '#! /bin/bash' > ${jobsh}
-              echo 'echo "*** Job started at: \$(date -R)"' >> ${jobsh}
-              echo 'echo "*** Job ID: \$SLURM_JOB_ID"' >> ${jobsh}
+              echo 'echo "*** Job started at .......: \$(date -R)"' >> ${jobsh}
+              echo 'echo "*** Job ID ...............: \$SLURM_JOB_ID"' >> ${jobsh}
               echo "source <(sed -e '/^#/d' -e '/^export/!s/^.*=/export &/' /etc/environment)" >> ${jobsh}
               echo "export LABEL=${label}" >> ${jobsh}
               echo "${env.SINGULARITY_CONTAINER_ROOT}/run_container ${container} ${ctestcmd}" >> ${jobsh}
@@ -70,7 +70,7 @@ pipeline {
             ctestcmd + " -DUSE_TEMPDIR:BOOL=ON", specs_list
           ) { spec, label, jobsh ->
             sh """
-              echo "*** Submitting at: \$(date -R)"
+              echo "*** Submitting job at ....: \$(date -R)"
               srun -p main -c 64 -n 1 -t 400 --job-name="${label}" bash ${jobsh}
             """
           }

--- a/test/buildsetup.sh
+++ b/test/buildsetup.sh
@@ -78,4 +78,8 @@ else
 	. thisfairsoft.sh
 fi
 
-echo "*** [$(date +%H:%M:%S)] Starting"
+echo -n "*** spack version ........: "
+spack --version
+
+echo -n "*** Actual test start time: "
+date +%H:%M:%S


### PR DESCRIPTION
On some cmake versions, the output of passed tests is truncated to 1024 Bytes. That's really not much. At least we would like to see the concretizer output! So increased this to 200k.

Let each test output the spack version that is being used. We should know it for each test. But better be verbose, as we're starting to mix versions.

And yet another round of reformatting output.