### PR TITLE
Replace `-C config` by site config

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ vgm@4-5
 The `jun19` FairSoft release pins certain package version and build variants that have been carefully chosen to work well together. To install the packages in the environment run
 
 ```
-[jun19] $ spack -C ./config install
+[jun19] $ spack install
 ```
 
 This step usually takes a while - time for a coffee break ☕.
@@ -210,12 +210,12 @@ View is created by following command:
 
 Linux
 ```
-[jun19] $ spack -C ./config view --verbose --dependencies true symlink -i (YOUR_SIMPATH) fairroot
+[jun19] $ spack view --verbose --dependencies true symlink -i (YOUR_SIMPATH) fairroot
 ```
 
 macOS
 ```
-[jun19] $ spack -C ./config view --verbose --dependencies true -e libpng -e libjpeg-turbo -e libiconv -e sqlite symlink -i (YOUR_SIMPATH) fairroot
+[jun19] $ spack view --verbose --dependencies true -e libpng -e libjpeg-turbo -e libiconv -e sqlite symlink -i (YOUR_SIMPATH) fairroot
 ```
 
 The view creation has to be done within an [activated environment](#iii2-activate-the-spack-environment).
@@ -238,7 +238,7 @@ A package can be built in development mode - without checking it out from reposi
 Following command will run development build of FairRoot with dependencies equivalent to jun19 environemnt on macOS. Currently this has to be configured manually.
 
 ```
-spack -C ./config dev-build -j JOBS -d SOURCE_PATH fairroot@18.2.1+sim+examples ^pcre+jit ^python@2.7.16 ^py-numpy@1.16.5 ^googletest@1.8.1 ^boost@1.68.0 ^fairlogger@1.4.0 \
+spack dev-build -j JOBS -d SOURCE_PATH fairroot@18.2.1+sim+examples ^pcre+jit ^python@2.7.16 ^py-numpy@1.16.5 ^googletest@1.8.1 ^boost@1.68.0 ^fairlogger@1.4.0 \
 ^dds@2.4 ^fairmq@1.4.3 ^pythia6@428-alice1 ^hepmc@2.06.09 length=CM momentum=GEV ^pythia8@8240 ^geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep~threads \
 ^root@6.16.00+fortran+gdml+memstat+pythia6+pythia8+vc~vdt+python+tmva+xrootd+aqua ^geant3@2-7_fairsoft ^vgm@4-5 ^geant4-vmc@4-0-p1
 ```
@@ -251,7 +251,7 @@ Releases are defined as a Spack environment in the directory [`env/<release>/<va
 
 `repo.yaml` + `packages/` constitute the FairSoft Spack package repository.
 
-`config/` contains some general configuration changes needed on some systems, please use it with `spack -C ./config ...`.
+`config/` contains some general configuration changes needed on some systems. It's merged into the spack site config directory.
 
 `spack/` is a git submodule which references the Spack git repo which currently contains both the Spack software and the Spack builtin package repository. Because some of the packages a FairSoft release pins down come from the Spack builtin repository, the idea is to pin it, too, to provide a reproducible build experience which does not depend on the various possible combination of Spack and FairSoft. The referenced submodule might also contain some extra patches, that we were not yet able to integrate into the upstream Spack itself.
 

--- a/test/buildenv.sh
+++ b/test/buildenv.sh
@@ -14,7 +14,7 @@ spack env activate $envname
 ret=$?
 if [ "$ret" = 0 ]
 then
-	spack -C ./config install
+	spack install
 	ret=$?
 fi
 spack env deactivate

--- a/test/buildsimple.sh
+++ b/test/buildsimple.sh
@@ -4,7 +4,7 @@
 
 echo "*** Spec to be build .....:" "$@"
 
-spack -C ./config spec -I "$@"
+spack spec -I "$@"
 retval=$?
 
 if [ "$retval" != "0" ]
@@ -12,4 +12,4 @@ then
 	exit $retval
 fi
 
-spack -C ./config install "$@"
+spack install "$@"

--- a/thisfairsoft.sh
+++ b/thisfairsoft.sh
@@ -1,14 +1,48 @@
 #!/bin/bash
 
 fairsoft_basedir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fairsoft_spackdir=spack
+fairsoft_configdir=../../../config
 
 if command -v git >/dev/null 2>&1
 then
 	(cd "$fairsoft_basedir" && git submodule update --init)
 fi
 
-. "${fairsoft_basedir}/spack/share/spack/setup-env.sh"
+. "${fairsoft_basedir}/${fairsoft_spackdir}/share/spack/setup-env.sh"
 spack compiler find
+
+(
+cd "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${fairsoft_configdir}"
+for config_entry in *
+do
+	case "$config_entry" in
+		*~)
+			continue
+			;;
+		.*)
+			continue
+			;;
+	esac
+	if [ "!" -e "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}" ]
+	then
+		ln -s "${fairsoft_configdir}/${config_entry}" \
+			"${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}"
+	else
+		fairsoft_readlink="$(readlink "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}")"
+		if [ "$fairsoft_readlink" != "${fairsoft_configdir}/${config_entry}" ]
+		then
+			echo "!!! WARNING"
+			echo "!!! ${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}"
+			echo "!!! does not point to the right target"
+			echo "!!! It should be a symlink to:"
+			echo "!!!     ${fairsoft_configdir}/${config_entry}"
+			echo "!!! Currently either not a symlink or points to:"
+			echo "!!!     $fairsoft_readlink"
+		fi
+	fi
+done
+)
 
 fairsoft_repo() {
 	if [ "$(spack repo list | sed -n -e "/^$1 / { s/^[^ ]* *//; p; }")" != "${fairsoft_basedir}/repos/$2" ]
@@ -22,3 +56,5 @@ fairsoft_repo "fairsoft" "fairsoft"
 
 unset -f fairsoft_repo
 unset fairsoft_basedir
+unset fairsoft_spackdir
+unset fairsoft_configdir

--- a/tools/spack_dev-build.sh
+++ b/tools/spack_dev-build.sh
@@ -23,7 +23,7 @@ if [[ "$#" -eq 1 ]]; then
     return
 fi
 
-coml="spack -C ./config dev-build -j 4 -d $2 $1@$3 $deps";
+coml="spack dev-build -j 4 -d $2 $1@$3 $deps";
 
 echo $coml;
 

--- a/vae/thisvae.sh
+++ b/vae/thisvae.sh
@@ -1,14 +1,48 @@
 #!/bin/bash
 
 fairsoft_basedir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fairsoft_spackdir=vae/spack
+fairsoft_configdir=../../../../config
 
 if command -v git >/dev/null 2>&1
 then
 	(cd "$fairsoft_basedir" && git submodule update --init)
 fi
 
-. "${fairsoft_basedir}/vae/spack/share/spack/setup-env.sh"
+. "${fairsoft_basedir}/${fairsoft_spackdir}/share/spack/setup-env.sh"
 spack compiler find
+
+(
+cd "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${fairsoft_configdir}"
+for config_entry in *
+do
+	case "$config_entry" in
+		*~)
+			continue
+			;;
+		.*)
+			continue
+			;;
+	esac
+	if [ "!" -e "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}" ]
+	then
+		ln -s "${fairsoft_configdir}/${config_entry}" \
+			"${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}"
+	else
+		fairsoft_readlink="$(readlink "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}")"
+		if [ "$fairsoft_readlink" != "${fairsoft_configdir}/${config_entry}" ]
+		then
+			echo "!!! WARNING"
+			echo "!!! ${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}"
+			echo "!!! does not point to the right target"
+			echo "!!! It should be a symlink to:"
+			echo "!!!     ${fairsoft_configdir}/${config_entry}"
+			echo "!!! Currently either not a symlink or points to:"
+			echo "!!!     $fairsoft_readlink"
+		fi
+	fi
+done
+)
 
 fairsoft_repo() {
 	if [ "$(spack repo list | sed -n -e "/^$1 / { s/^[^ ]* *//; p; }")" != "${fairsoft_basedir}/repos/$2" ]
@@ -23,3 +57,5 @@ fairsoft_repo "fairsoft" "fairsoft"
 
 unset -f fairsoft_repo
 unset fairsoft_basedir
+unset fairsoft_spackdir
+unset fairsoft_configdir


### PR DESCRIPTION
Instead of requiring each user to specify `-C config` on each spack invocation, merge the appropriate config into the site config dir (spack/etc/config).

thisfairsoft.sh and thisvae.sh now symlink the config directory contents into the site config directory. They also check the existing symlinks and warn, if they're not pointing to the right place. That way, a user can override, if they need to.

Also removed all references to `-C ./config` everywhere.