### PR TITLE
CI/slurm: Make requested CPUs more configurable

### DIFF
--- a/test/slurm-submit.sh
+++ b/test/slurm-submit.sh
@@ -11,11 +11,17 @@ jobsh="$2"
 
 [ -e "build/${label}-last-exit-code" ] && rm "build/${label}-last-exit-code"
 
+if [ -z "$ALFACI_SLURM_CPUS" ]
+then
+	ALFACI_SLURM_CPUS=32
+fi
+
 echo "*** Working directory ....: $PWD"
+echo "*** Requesting CPUs ......: $ALFACI_SLURM_CPUS"
 echo "*** Submitting job at ....: $(date -R)"
 (
 	set -x
-	srun -p main -c 64 -n 1 -t 400 --job-name="${label}" bash "${jobsh}"
+	srun -p main -c $ALFACI_SLURM_CPUS -n 1 -t 400 --job-name="${label}" bash "${jobsh}"
 )
 retval=$?
 if [ "$retval" != 0 ]


### PR DESCRIPTION
If ALFACI_SLURM_CPUS is set, then the value gives the number of CPUs that will be requested via slurm.  This value can be set in jenkins or shell setup scripts, as needed.

Also lower the default from 64 to 32.  Let's see, if this has a major wall time effect.