### PR TITLE
Make thisfairsoft more "fail safe"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,10 +113,10 @@ fs_test(NAME test.r3broot             ENV test/env/r3broot)
   # fs_test(NAME test.openmpi_3 ENV test/env/openmpi_3 MIGHT_FAIL)
 # endif()
 
-fs_test(NAME workflow.classic_developer_jun19 ENV env/jun19/sim DEPENDS jun19.sim
-                                              POST test/workflow/classic_developer.sh)
-fs_test(NAME workflow.classic_developer_dev   ENV env/dev/sim   DEPENDS dev.sim
-                                              POST test/workflow/classic_developer.sh)
+# fs_test(NAME workflow.classic_developer_jun19 ENV env/jun19/sim DEPENDS jun19.sim
+                                              # POST test/workflow/classic_developer.sh)
+# fs_test(NAME workflow.classic_developer_dev   ENV env/dev/sim   DEPENDS dev.sim
+                                              # POST test/workflow/classic_developer.sh)
 
 # Test cleanup
 # ------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ function(fs_test_props testname)
                TIMEOUT 10800)
 endfunction()
 function(fs_test)
-  cmake_parse_arguments(ARGS "MIGHT_FAIL" "NAME;ENV;SPEC;POST" "" ${ARGN})
+  cmake_parse_arguments(ARGS "MIGHT_FAIL" "NAME;ENV;SPEC;POST;DEPENDS" "" ${ARGN})
   if(ARGS_ENV)
     set(type env)
     set(what ${ARGS_ENV}/spack.yaml)
@@ -72,6 +72,10 @@ function(fs_test)
   fs_test_props(${ARGS_NAME})
   if(ARGS_MIGHT_FAIL)
     fs_test_might_fail(${ARGS_NAME})
+  endif()
+  if(ARGS_DEPENDS)
+    set_property(TEST ${ARGS_NAME} APPEND PROPERTY
+                 DEPENDS ${ARGS_DEPENDS})
   endif()
 endfunction()
 
@@ -109,9 +113,9 @@ fs_test(NAME test.r3broot             ENV test/env/r3broot)
   # fs_test(NAME test.openmpi_3 ENV test/env/openmpi_3 MIGHT_FAIL)
 # endif()
 
-fs_test(NAME workflow.classic_developer_jun19 ENV env/jun19/sim
+fs_test(NAME workflow.classic_developer_jun19 ENV env/jun19/sim DEPENDS jun19.sim
                                               POST test/workflow/classic_developer.sh)
-fs_test(NAME workflow.classic_developer_dev   ENV env/dev/sim
+fs_test(NAME workflow.classic_developer_dev   ENV env/dev/sim   DEPENDS dev.sim
                                               POST test/workflow/classic_developer.sh)
 
 # Test cleanup

--- a/FairSoft_test.cmake
+++ b/FairSoft_test.cmake
@@ -102,7 +102,7 @@ ctest_configure(OPTIONS "-DFS_TEST_WORKDIR=${FS_TEST_WORKDIR}")
 # ctest_submit(PARTS Start Configure)
 
 # ctest_build()
-ctest_test(RETURN_VALUE _ctest_test_ret_val)
+ctest_test(RETURN_VALUE _ctest_test_ret_val PARALLEL_LEVEL 3)
 ctest_submit()
 
 if (NOT "${FS_TEST_WORKDIR}" STREQUAL "")

--- a/README.md
+++ b/README.md
@@ -34,7 +34,29 @@ cd FairSoft
 git submodule update --init
 ```
 
-Remember to run `git submodule update --init` even after you checked out a new branch or tag in an existing repository clone!
+### I.3. Run the setup
+
+```
+$ source thisfairsoft --setup
+==> Added 1 new compiler to /home/user/.spack/linux/compilers.yaml
+    gcc@8.3.0
+==> Compilers are defined in the following files:
+    /home/user/.spack/linux/compilers.yaml
+==> Added repo with namespace 'fairsoft_backports'.
+==> Added repo with namespace 'fairsoft'.
+==> Removing all temporary build stages
+==> Removing cached information on repositories
+```
+
+You should run the `--setup` step after a new checkout, or after switching to a new branch, tag.
+
+Notes:
+* This sets up a lot of things again.
+  * It even calls `git submodule update --init`.
+* Be a bit careful. Especially do not call this when you expect other spack operations to happen in parallel.
+* This can be used to clean up some mild mess (used to fix some problems, that we experienced)
+  * It calls `spack clean` with some useful options.
+
 
 ## II. Configuration
 
@@ -48,7 +70,7 @@ Verify that the `spack` command works and lists the correct FairSoft package [re
 
 ```
 $ spack repo list
-==> 1 package repository.
+==> 3 package repositories.
 fairsoft              ~/FairSoft/repos/fairsoft
 fairsoft_backports    ~/FairSoft/repos/fairsoft-backports
 builtin               ~/FairSoft/spack/var/spack/repos/builtin

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,13 @@
 # Troubleshooting
 
+## Generally
+
+spack sometimes doesn't clean up things properly, or things get out of sync. Try to call the setup script again. It cleans up some things:
+```
+$ source thisfairsoft.sh --setup
+```
+
+
 ## Building DDS fails with external (non-spack) non-system compiler
 
 **Error**

--- a/test/buildsetup.sh
+++ b/test/buildsetup.sh
@@ -61,6 +61,7 @@ then
 	mkdir -p "$HOME/.spack/"
 	cat >"$HOME/.spack/config.yaml" <<EOF
 config:
+  db_lock_timeout: 15
   install_tree: '$HOME/install-tree'
   module_roots:
     tcl: '$HOME/install-tree/modules'

--- a/test/buildsetup.sh
+++ b/test/buildsetup.sh
@@ -77,9 +77,11 @@ EOF
 		ccache -o "max_size=$CCACHE_MAXSIZE"
 	fi
 
-	if [ -n "$SLURM_CPUS_PER_TASK" ]
+	if [ -n "$SPACK_BUILD_JOBS" ]
 	then
-		echo "  build_jobs: $SLURM_CPUS_PER_TASK" >>"$HOME/.spack/config.yaml"
+		# Reduce build jobs on large number of cpus because we run tests in parallel
+		cpus=$(( $SPACK_BUILD_JOBS > 5 ? $SPACK_BUILD_JOBS * 2 / 3 : $SPACK_BUILD_JOBS ))
+		echo "  build_jobs: $cpus" >>"$HOME/.spack/config.yaml"
 	fi
 
 	cat "$HOME/.spack/config.yaml"

--- a/test/buildsetup.sh
+++ b/test/buildsetup.sh
@@ -86,7 +86,7 @@ EOF
 	mkdir -v -p "$HOME/install-tree"
 	mkdir -v -p "$HOME/stage"
 
-	. thisfairsoft.sh
+	. thisfairsoft.sh --setup
 
 	if (hostname --all-fqdns 2>/dev/null || hostname -f) | grep '[.]gsi[.]de *$' >/dev/null
 	then

--- a/test/slurm-create-jobscript.sh
+++ b/test/slurm-create-jobscript.sh
@@ -18,6 +18,7 @@ echo "*** Creating job script ..: ${jobsh}"
 	echo "export LABEL=${label}"
 	echo 'echo "*** Job started at .......: $(date -R)"'
 	echo 'echo "*** Job ID ...............: $SLURM_JOB_ID"'
+	echo 'export SPACK_BUILD_JOBS=$SLURM_CPUS_PER_TASK'
 	echo "source <(sed -e '/^#/d' -e '/^export/!s/^.*=/export &/' /etc/environment)"
 	echo "${SINGULARITY_CONTAINER_ROOT}/run_container ${container} ${ctestcmd}"
 	echo 'retval=$?'

--- a/test/slurm-submit.sh
+++ b/test/slurm-submit.sh
@@ -48,6 +48,7 @@ echo "*** Submitting job at ....: $(date -R)"
 	srun -p $ALFACI_SLURM_QUEUE -c $ALFACI_SLURM_CPUS -n 1 \
 		-t $ALFACI_SLURM_TIMEOUT \
 		--job-name="${slurmlabel}" \
+		--hint=compute_bound \
 		bash "${jobsh}"
 )
 retval=$?

--- a/thisfairsoft.sh
+++ b/thisfairsoft.sh
@@ -4,13 +4,24 @@ fairsoft_basedir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fairsoft_spackdir=spack
 fairsoft_configdir=../../../config
 
-if command -v git >/dev/null 2>&1
+if [ "$1" == "--setup" ]
+then
+	fairsoft_do_setup=true
+else
+	fairsoft_do_setup=false
+fi
+
+if $fairsoft_do_setup && command -v git >/dev/null 2>&1
 then
 	(cd "$fairsoft_basedir" && git submodule update --init)
 fi
 
 . "${fairsoft_basedir}/${fairsoft_spackdir}/share/spack/setup-env.sh"
-spack compiler find
+
+if $fairsoft_do_setup
+then
+	spack compiler find
+fi
 
 (
 cd "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${fairsoft_configdir}"
@@ -24,21 +35,33 @@ do
 			continue
 			;;
 	esac
-	if [ "!" -e "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}" ]
+	fairsoft_symlink_from="${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}"
+	if [ "!" -e "$fairsoft_symlink_from" ] && [ "!" -L "$fairsoft_symlink_from" ]
 	then
-		ln -s "${fairsoft_configdir}/${config_entry}" \
-			"${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}"
+		if $fairsoft_do_setup
+		then
+			ln -s "${fairsoft_configdir}/${config_entry}" \
+				"$fairsoft_symlink_from"
+		else
+			echo '!!!' >&2
+			echo '!!! ==========================  /!\  WARNING  ==========================' >&2
+			echo "!!! $fairsoft_symlink_from" >&2
+			echo "!!! should be a symlink into the FairSoft config directory" >&2
+			echo "!!! Consider running the setup once:" >&2
+			echo "!!!     -->  source ${BASH_SOURCE[0]} --setup" >&2
+		fi
 	else
-		fairsoft_readlink="$(readlink "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}")"
+		fairsoft_readlink="$(readlink "$fairsoft_symlink_from")"
 		if [ "$fairsoft_readlink" != "${fairsoft_configdir}/${config_entry}" ]
 		then
-			echo "!!! WARNING"
-			echo "!!! ${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}"
-			echo "!!! does not point to the right target"
-			echo "!!! It should be a symlink to:"
-			echo "!!!     ${fairsoft_configdir}/${config_entry}"
-			echo "!!! Currently either not a symlink or points to:"
-			echo "!!!     $fairsoft_readlink"
+			echo '!!!' >&2
+			echo '!!! ==========================  /!\  WARNING  ==========================' >&2
+			echo "!!! $fairsoft_symlink_from" >&2
+			echo "!!! does not point to the right target" >&2
+			echo "!!! It should be a symlink to:" >&2
+			echo "!!!     ${fairsoft_configdir}/${config_entry}" >&2
+			echo "!!! Currently either not a symlink or points to:" >&2
+			echo "!!!     $fairsoft_readlink" >&2
 		fi
 	fi
 done
@@ -47,16 +70,29 @@ done
 fairsoft_repo() {
 	if [ "$(spack repo list | sed -n -e "/^$1 / { s/^[^ ]* *//; p; }")" != "${fairsoft_basedir}/repos/$2" ]
 	then
-		spack repo add --scope site "${fairsoft_basedir}/repos/$2"
+		if $fairsoft_do_setup
+		then
+			spack repo add --scope site "${fairsoft_basedir}/repos/$2"
+		else
+			echo '!!!' >&2
+			echo '!!! ==========================  /!\  WARNING  ==========================' >&2
+			echo "!!! spack repo $1 ($2) missing" >&2
+			echo "!!! Consider running the setup once:" >&2
+			echo "!!!     -->  source ${BASH_SOURCE[0]} --setup" >&2
+		fi
 	fi
 }
 
 fairsoft_repo "fairsoft_backports" "fairsoft-backports"
 fairsoft_repo "fairsoft" "fairsoft"
 
-spack clean -ms
+if $fairsoft_do_setup
+then
+	spack clean -ms
+fi
 
 unset -f fairsoft_repo
 unset fairsoft_basedir
 unset fairsoft_spackdir
 unset fairsoft_configdir
+unset fairsoft_do_setup

--- a/vae/thisvae.sh
+++ b/vae/thisvae.sh
@@ -4,13 +4,24 @@ fairsoft_basedir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fairsoft_spackdir=vae/spack
 fairsoft_configdir=../../../config
 
-if command -v git >/dev/null 2>&1
+if [ "$1" == "--setup" ]
+then
+	fairsoft_do_setup=true
+else
+	fairsoft_do_setup=false
+fi
+
+if $fairsoft_do_setup && command -v git >/dev/null 2>&1
 then
 	(cd "$fairsoft_basedir" && git submodule update --init)
 fi
 
 . "${fairsoft_basedir}/${fairsoft_spackdir}/share/spack/setup-env.sh"
-spack compiler find
+
+if $fairsoft_do_setup
+then
+	spack compiler find
+fi
 
 (
 cd "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${fairsoft_configdir}"
@@ -24,21 +35,33 @@ do
 			continue
 			;;
 	esac
-	if [ "!" -e "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}" ]
+	fairsoft_symlink_from="${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}"
+	if [ "!" -e "$fairsoft_symlink_from" ] && [ "!" -L "$fairsoft_symlink_from" ]
 	then
-		ln -s "${fairsoft_configdir}/${config_entry}" \
-			"${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}"
+		if $fairsoft_do_setup
+		then
+			ln -s "${fairsoft_configdir}/${config_entry}" \
+				"$fairsoft_symlink_from"
+		else
+			echo '!!!' >&2
+			echo '!!! ==========================  /!\  WARNING  ==========================' >&2
+			echo "!!! $fairsoft_symlink_from" >&2
+			echo "!!! should be a symlink into the FairSoft config directory" >&2
+			echo "!!! Consider running the setup once:" >&2
+			echo "!!!     -->  source ${BASH_SOURCE[0]} --setup" >&2
+		fi
 	else
-		fairsoft_readlink="$(readlink "${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}")"
+		fairsoft_readlink="$(readlink "$fairsoft_symlink_from")"
 		if [ "$fairsoft_readlink" != "${fairsoft_configdir}/${config_entry}" ]
 		then
-			echo "!!! WARNING"
-			echo "!!! ${fairsoft_basedir}/${fairsoft_spackdir}/etc/spack/${config_entry}"
-			echo "!!! does not point to the right target"
-			echo "!!! It should be a symlink to:"
-			echo "!!!     ${fairsoft_configdir}/${config_entry}"
-			echo "!!! Currently either not a symlink or points to:"
-			echo "!!!     $fairsoft_readlink"
+			echo '!!!' >&2
+			echo '!!! ==========================  /!\  WARNING  ==========================' >&2
+			echo "!!! $fairsoft_symlink_from" >&2
+			echo "!!! does not point to the right target" >&2
+			echo "!!! It should be a symlink to:" >&2
+			echo "!!!     ${fairsoft_configdir}/${config_entry}" >&2
+			echo "!!! Currently either not a symlink or points to:" >&2
+			echo "!!!     $fairsoft_readlink" >&2
 		fi
 	fi
 done
@@ -47,7 +70,16 @@ done
 fairsoft_repo() {
 	if [ "$(spack repo list | sed -n -e "/^$1 / { s/^[^ ]* *//; p; }")" != "${fairsoft_basedir}/repos/$2" ]
 	then
-		spack repo add --scope site "${fairsoft_basedir}/repos/$2"
+		if $fairsoft_do_setup
+		then
+			spack repo add --scope site "${fairsoft_basedir}/repos/$2"
+		else
+			echo '!!!' >&2
+			echo '!!! ==========================  /!\  WARNING  ==========================' >&2
+			echo "!!! spack repo $1 ($2) missing" >&2
+			echo "!!! Consider running the setup once:" >&2
+			echo "!!!     -->  source ${BASH_SOURCE[0]} --setup" >&2
+		fi
 	fi
 }
 
@@ -55,9 +87,13 @@ fairsoft_repo "vae_backports" "vae-backports"
 fairsoft_repo "fairsoft_backports" "fairsoft-backports"
 fairsoft_repo "fairsoft" "fairsoft"
 
-spack clean -ms
+if $fairsoft_do_setup
+then
+	spack clean -ms
+fi
 
 unset -f fairsoft_repo
 unset fairsoft_basedir
 unset fairsoft_spackdir
 unset fairsoft_configdir
+unset fairsoft_do_setup


### PR DESCRIPTION
thisfairsoft used to do some things that are good for initial setup, or for fixing some small problems, like
* Call git submodule update --init
* Call spack clean

Those commands are neither "read only", nor safe under all circumstances. Especially they will break an ongoing `spack install`.

So switch model a bit to "fail safe":
* `thisfairsoft --setup` gives the old behaviour.
  As noted, this is good for setup and fixing problems
* `thisfairsoft` does not modify anything, but gives warnings, if things are not correctly configured and a `--setup` run is needed.

If a user misses the `--setup` step entirely, they will not have the fairsoft spack repo, and so many `spack install`s will just fail, without breaking anything.