### PR TITLE
Update glew; CI cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ macro(fs_test_might_fail testname)
 endmacro()
 function(fs_test_props_base testname)
   set_property(TEST ${testname} APPEND PROPERTY ENVIRONMENT
-               TARGETDIR=${FS_TEST_WORKDIR})
+               FS_TEST_WORKDIR=${FS_TEST_WORKDIR})
   set_property(TEST ${testname} APPEND PROPERTY ENVIRONMENT
                CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR})
 endfunction()

--- a/FairSoft_test.cmake
+++ b/FairSoft_test.cmake
@@ -9,21 +9,31 @@
 message(STATUS " Starting CTest script : FairSoft_test.cmake")
 message(STATUS " CMake Version ........: ${CMAKE_VERSION}")
 
+
+# Set some default values, etc.
+set(CTEST_BINARY_DIRECTORY build)
+set(CTEST_TEST_TIMEOUT 10800)
+set(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 204800)
+set(CTEST_USE_LAUNCHERS ON)
+set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+
+
 if (USE_TEMPDIR)
     execute_process(COMMAND mktemp -d --tmpdir fairsoft_ctest.XXXXXX
-                    OUTPUT_VARIABLE FS_TEST_WORKDIR
+                    OUTPUT_VARIABLE FS_TEST_WORKDIR_TEMP
                     OUTPUT_STRIP_TRAILING_WHITESPACE
                     RESULT_VARIABLE res)
     if (res)
         execute_process(COMMAND mktemp -d
-                        OUTPUT_VARIABLE FS_TEST_WORKDIR
+                        OUTPUT_VARIABLE FS_TEST_WORKDIR_TEMP
                         OUTPUT_STRIP_TRAILING_WHITESPACE
                         RESULT_VARIABLE res)
     endif()
     if (res)
         message(FATAL_ERROR "Temp dir creation failed: ${res}")
     endif()
-    message(STATUS " CTest workdir ........: ${FS_TEST_WORKDIR}")
+    set(FS_TEST_WORKDIR "${FS_TEST_WORKDIR_TEMP}")
+    message(STATUS " CTest workdir (temp) .: ${FS_TEST_WORKDIR}")
 else()
     set(FS_TEST_WORKDIR "")
 endif()
@@ -43,11 +53,6 @@ else()
     message(STATUS "${timestamp} ... done")
 endif()
 
-set(CTEST_BINARY_DIRECTORY build)
-set(CTEST_TEST_TIMEOUT 10800)
-set(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 204800)
-set(CTEST_USE_LAUNCHERS ON)
-set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 cmake_host_system_information(RESULT fqdn QUERY FQDN)
 
 message(STATUS " Running on host ......: ${fqdn}")
@@ -105,10 +110,10 @@ ctest_configure(OPTIONS "-DFS_TEST_WORKDIR=${FS_TEST_WORKDIR}")
 ctest_test(RETURN_VALUE _ctest_test_ret_val)
 ctest_submit()
 
-if (NOT "${FS_TEST_WORKDIR}" STREQUAL "")
+if (NOT "${FS_TEST_WORKDIR_TEMP}" STREQUAL "")
     string(TIMESTAMP timestamp "[%H:%M:%S]")
-    message(STATUS "${timestamp} Removing directory: ${FS_TEST_WORKDIR}")
-    file(REMOVE_RECURSE "${FS_TEST_WORKDIR}")
+    message(STATUS "${timestamp} Removing directory: ${FS_TEST_WORKDIR_TEMP}")
+    file(REMOVE_RECURSE "${FS_TEST_WORKDIR_TEMP}")
 endif()
 
 if (_ctest_test_ret_val)

--- a/repos/fairsoft-backports/packages/glew/package.py
+++ b/repos/fairsoft-backports/packages/glew/package.py
@@ -10,8 +10,9 @@ class Glew(Package):
     """The OpenGL Extension Wrangler Library."""
 
     homepage = "http://glew.sourceforge.net/"
-    url      = "https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download"
+    url      = "https://sourceforge.net/projects/glew/files/glew/2.1.0/glew-2.1.0.tgz/download"
 
+    version('2.1.0',  sha256='04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95')
     version('2.0.0',  sha256='c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764')
 
     depends_on("cmake", type='build')

--- a/repos/fairsoft-backports/packages/glew/package.py
+++ b/repos/fairsoft-backports/packages/glew/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Glew(Package):
+    """The OpenGL Extension Wrangler Library."""
+
+    homepage = "http://glew.sourceforge.net/"
+    url      = "https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download"
+
+    version('2.0.0',  sha256='c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764')
+
+    depends_on("cmake", type='build')
+    depends_on("gl")
+    depends_on('libsm')
+    depends_on('libice')
+
+    def install(self, spec, prefix):
+        options = []
+        options.extend(std_cmake_args)
+
+        with working_dir('build'):
+            cmake('./cmake/', *options)
+
+            # https://github.com/Homebrew/legacy-homebrew/issues/22025
+            # Note: This file is generated only after cmake is run
+            filter_file(r'Requires: glu',
+                        (''), '../glew.pc')
+
+            make()
+            make("install")

--- a/test/build-main-tests-common.sh
+++ b/test/build-main-tests-common.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+#  -- to be sourced
+
+. test/buildsetup.sh
+
+echo -n "*** spack version ........: "
+spack --version
+
+echo -n "*** Actual test start time: "
+date +%H:%M:%S

--- a/test/buildenv.sh
+++ b/test/buildenv.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. test/buildsetup.sh
+. test/build-main-tests-common.sh
 
 envname="$(echo "${1}" | \
 	sed \

--- a/test/buildsetup.sh
+++ b/test/buildsetup.sh
@@ -95,9 +95,3 @@ EOF
 else
 	. thisfairsoft.sh
 fi
-
-echo -n "*** spack version ........: "
-spack --version
-
-echo -n "*** Actual test start time: "
-date +%H:%M:%S

--- a/test/buildsetup.sh
+++ b/test/buildsetup.sh
@@ -39,12 +39,12 @@ fi
 # echo -n "*** Number of threads per python: "
 # python3 -c 'import multiprocessing; print(multiprocessing.cpu_count())'
 
-if [ ! -d "$TARGETDIR" ]
+if [ ! -d "$FS_TEST_WORKDIR" ]
 then
-	TARGETDIR="$(mktemp -d)"
-	echo "*** Created test directory: $TARGETDIR"
+	FS_TEST_WORKDIR="$(mktemp -d)"
+	echo "*** Created test directory: $FS_TEST_WORKDIR"
 else
-	echo "*** Reusing test directory: $TARGETDIR"
+	echo "*** Reusing test directory: $FS_TEST_WORKDIR"
 fi
 
 if [ "$SPACK_CCACHE" = "true" ]
@@ -53,7 +53,7 @@ then
   CCACHE_MAXSIZE="$(ccache -k max_size)"
 fi
 
-export HOME="$TARGETDIR"
+export HOME="$FS_TEST_WORKDIR"
 
 if [ ! -d "$HOME/.spack/" ]
 then

--- a/test/buildspec.sh
+++ b/test/buildspec.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. test/buildsetup.sh
+. test/build-main-tests-common.sh
 
 echo "*** Spec to be build .....:" "$@"
 

--- a/test/buildstart.sh
+++ b/test/buildstart.sh
@@ -1,8 +1,14 @@
 #! /bin/bash
 
-echo "*** Setting things up:"
+echo "***"
+echo "***       Setting things up"
+echo "***       ================="
+echo "***"
 
 . test/buildsetup.sh
+
+echo "*** 'spack debug report'"
+spack debug report | sed -e 's/^/    /'
 
 
 function handle_gitdifflist() {
@@ -35,3 +41,8 @@ then
 	git diff --name-only -z "origin/$CHANGE_TARGET" HEAD -- \
 		| handle_gitdifflist
 fi
+
+echo "***"
+echo "***       Done with settings things up"
+echo "***       ============================"
+echo "***"


### PR DESCRIPTION
glew 2.1.0 has fixes for macOS (shared libraries, as usual)

CI:
* More consistent naming of variables
* Remove temporary directories only, if we created them