### PR TITLE
Enable install tree caching on our macs

### DIFF
--- a/test/buildstart.sh
+++ b/test/buildstart.sh
@@ -49,6 +49,17 @@ then
 		| handle_gitdifflist
 fi
 
+if [ -r "$FS_TEST_INSTALLTREE/sha1-stamps" ]
+then
+	cat "$FS_TEST_INSTALLTREE/sha1-stamps" | sort | uniq \
+	| while read sha1
+	do
+		echo "***    Comparing $sha1 to worktree"
+		git diff --name-only -z "$sha1" \
+			| handle_gitdifflist
+	done
+fi
+
 echo "***"
 echo "***       Done with settings things up"
 echo "***       ============================"

--- a/test/buildstart.sh
+++ b/test/buildstart.sh
@@ -20,9 +20,14 @@ function handle_gitdifflist() {
 				pkg="${filename#repos/*/packages/}"
 				pkg="${pkg%%/*}"
 				echo "***    |   uninstall '$pkg'"
+				spack uninstall --all --dependents -y "$pkg"
 				;;
 			spack|config/*)
 				echo "***    |   spack was changed, needing to wipe everything"
+				( cd "$FS_TEST_INSTALLTREE" && \
+					find . -mindepth 1 -maxdepth 2 -depth \
+						-type d -print0 \
+						| xargs -0 -n 1 -t rm -rf )
 				;;
 			env/*.yaml|Jenkinsfile|CMakeLists.txt|*.cmake|test/*)
 				echo "***    |   Ignoring"
@@ -35,9 +40,11 @@ function handle_gitdifflist() {
 }
 
 
+echo "*** Checking changes and deleting out-dated packages"
+
 if [ -n "$CHANGE_ID" -a -n "$CHANGE_TARGET" ]
 then
-	echo "*** Analyzing list and acting"
+	echo "***    Comparing origin/$CHANGE_TARGET to HEAD"
 	git diff --name-only -z "origin/$CHANGE_TARGET" HEAD -- \
 		| handle_gitdifflist
 fi


### PR DESCRIPTION
First, implement the uninstall part

Second, write ths git sha1 of the currently building version into a stamp file in the install-tree, so that we have something to compare against at the next run.

* If the run is starting (and thus unknown), then the sha1 is appended, as, the tree might still reflect something from the previous run(s).
* If the run is successful, then replace the complete contents with the current sha1