### PR TITLE
CI/Linux: Use persistant install tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ function(fs_test_props testname)
                TIMEOUT 14400)
 endfunction()
 function(fs_test)
-  cmake_parse_arguments(ARGS "MIGHT_FAIL" "NAME;ENV;SPEC;POST;DEPENDS" "" ${ARGN})
+  cmake_parse_arguments(ARGS "MIGHT_FAIL" "NAME;ENV;SPEC;POST" "DEPENDS" ${ARGN})
   if(ARGS_ENV)
     set(type env)
     set(what ${ARGS_ENV}/spack.yaml)
@@ -115,10 +115,12 @@ fs_test(NAME test.fairroot_develop    ENV test/env/fairroot_develop)
 fs_test(NAME test.r3broot             ENV test/env/r3broot)
 
 fs_test(NAME workflow.classic_developer_jun19
-        ENV env/jun19/sim DEPENDS jun19.sim
+        ENV env/jun19/sim
+        DEPENDS jun19.sim
         POST test/workflow/classic_developer.sh)
 fs_test(NAME workflow.classic_developer_dev
-        ENV env/dev/sim   DEPENDS dev.sim
+        ENV env/dev/sim
+        DEPENDS "dev.sim;workflow.classic_developer_jun19"
         POST test/workflow/classic_developer.sh)
 
 # Test cleanup

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,13 @@
 #!groovy
 
+// Default quiet period for branches
+Integer our_quiet_period = 600;
+if (env.CHANGE_ID != null) {
+    // Pull Requests get default
+    our_quiet_period = 5;
+}
+
+
 def jobMatrix(String node_type, String ctestcmd, List specs, Closure callback) {
   def nodes = [:]
   for (spec in specs) {
@@ -39,8 +47,20 @@ def jobMatrix(String node_type, String ctestcmd, List specs, Closure callback) {
 }
 
 pipeline {
+  options {
+    quietPeriod(our_quiet_period)
+  }
   agent none
   stages {
+    stage('Info Stage') {
+      steps {
+        echo "BRANCH_NAME: ${BRANCH_NAME}"
+        echo "env.BRANCH_NAME: ${env.BRANCH_NAME}"
+        echo "env.CHANGE_ID: ${env.CHANGE_ID}"
+        echo "getBuildCauses: ${currentBuild.getBuildCauses()}"
+        echo "our_quiet_period: ${our_quiet_period}"
+      }
+    }
     stage('Run CI Matrix') {
       steps{
         script {

--- a/test/slurm-create-jobscript.sh
+++ b/test/slurm-create-jobscript.sh
@@ -20,7 +20,7 @@ echo "*** Creating job script ..: ${jobsh}"
 	echo 'echo "*** Job ID ...............: $SLURM_JOB_ID"'
 	echo 'export SPACK_BUILD_JOBS=$SLURM_CPUS_PER_TASK'
 	echo "source <(sed -e '/^#/d' -e '/^export/!s/^.*=/export &/' /etc/environment)"
-	echo "${SINGULARITY_CONTAINER_ROOT}/run_container ${container} ${ctestcmd}"
+	printf './test/test-start-container.sh %q %q\n' "${container}" "${ctestcmd}"
 	echo 'retval=$?'
 	echo 'mkdir -p build'
 	echo 'echo $retval >"build/${LABEL}-last-exit-code"'

--- a/test/slurm-submit.sh
+++ b/test/slurm-submit.sh
@@ -27,6 +27,10 @@ if [ -z "$ALFACI_SLURM_CPUS" ]
 then
 	ALFACI_SLURM_CPUS=32
 fi
+if [ -z "$ALFACI_SLURM_EXTRA_OPTS" ]
+then
+	ALFACI_SLURM_EXTRA_OPTS="--hint=compute_bound"
+fi
 if [ -z "$ALFACI_SLURM_TIMEOUT" ]
 then
 	ALFACI_SLURM_TIMEOUT=480
@@ -35,6 +39,11 @@ if [ -z "$ALFACI_SLURM_QUEUE" ]
 then
 	ALFACI_SLURM_QUEUE=main
 fi
+if [ -n "$BRANCH_NAME" ] && [ -z "$CHANGE_ID" ]
+then
+	# jenkins: Building branch, not PR
+	ALFACI_SLURM_EXTRA_OPTS="${ALFACI_SLURM_EXTRA_OPTS} --nice=1000"
+fi
 
 echo "*** Slurm request options :"
 echo "***   Working directory ..: $PWD"
@@ -42,13 +51,14 @@ echo "***   Queue ..............: $ALFACI_SLURM_QUEUE"
 echo "***   CPUs ...............: $ALFACI_SLURM_CPUS"
 echo "***   Wall Time ..........: $ALFACI_SLURM_TIMEOUT min"
 echo "***   Job Name ...........: ${slurmlabel}"
+echo "***   Extra Options ......: ${ALFACI_SLURM_EXTRA_OPTS}"
 echo "*** Submitting job at ....: $(date -R)"
 (
 	set -x
 	srun -p $ALFACI_SLURM_QUEUE -c $ALFACI_SLURM_CPUS -n 1 \
 		-t $ALFACI_SLURM_TIMEOUT \
 		--job-name="${slurmlabel}" \
-		--hint=compute_bound \
+		${ALFACI_SLURM_EXTRA_OPTS} \
 		bash "${jobsh}"
 )
 retval=$?

--- a/test/test-start-container.sh
+++ b/test/test-start-container.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+if [ $# != 2 ]
+then
+	echo "*** Please call like: $0 CONTAINER CTESTCMD"
+	exit 1
+fi
+
+container="$1"
+ctestcmd="$2"
+
+if [ -z "$FS_INSTALLTREE_BASE" ]
+then
+	FS_INSTALLTREE_BASE=/srv/alfaci/FairSoft/install-tree
+fi
+image="${SINGULARITY_CONTAINER_ROOT}/${container}"
+bindmounts="/etc/environment,/cvmfs,$PWD"
+
+if [ -d "$FS_INSTALLTREE_BASE" ]
+then
+	mkdir -p "$FS_INSTALLTREE_BASE/running"
+	installtree="$(mktemp -d "$FS_INSTALLTREE_BASE/running/${LABEL}.${JOB_BASE_NAME}.XXX")"
+	echo "*** New install tree .....: ${installtree}"
+	bindmounts="${bindmounts},${installtree}:/opt/spack/install-tree"
+	ctestcmd="${ctestcmd} -DFS_TEST_INSTALLTREE:PATH=/opt/spack/install-tree"
+fi
+
+set -x
+exec singularity run -B"$bindmounts" "$image" ${ctestcmd}


### PR DESCRIPTION
Instead of putting the install tree inside newly created temp directory, put it in `/srv/alfaci/FairSoft/install-tree`.

The directory is bind-mounted as `/opt/spack/install-tree` into the container, so that the container always sees the same path.

The stuff is cached per "job" (PR, branch). So this somewhat brings the Linux builds on the same level as the mac builds.