### PR TITLE
Fix Python 3.8 on macOS

### DIFF
--- a/test/buildcleanup.sh
+++ b/test/buildcleanup.sh
@@ -2,8 +2,8 @@
 
 . test/buildsetup.sh
 
-installedMB="$(cd $HOME/install-tree && du -ms . | sed -e 's/[	 ].*$//')"
-# rm -rf "$HOME/install-tree"
+installedMB="$(cd "$FS_TEST_INSTALLTREE" && du -ms . | sed -e 's/[	 ].*$//')"
+# rm -rf "$FS_TEST_INSTALLTREE"
 
 # stageKB="$(cd $HOME/stage && du -ks . | sed -e 's/[	 ].*$//')"
 (cd "$HOME" && du -sh stage)

--- a/test/buildstart.sh
+++ b/test/buildstart.sh
@@ -11,32 +11,51 @@ echo "*** 'spack debug report'"
 spack debug report | sed -e 's/^/    /'
 
 
+function wipe_install_tree() {
+	echo "***    |   Wiping complete install tree"
+	( cd "$FS_TEST_INSTALLTREE" && \
+		find . -mindepth 1 -maxdepth 2 -depth \
+			-type d -print0 \
+			| xargs -0 -n 1 -t rm -rf )
+}
+
 function handle_gitdifflist() {
 	while read -d "" filename
 	do
-		echo "***    | + '$filename'"
+		printf "***    |-- %q" "$filename"
 		case "$filename" in
 			repos/*/packages/*)
+				echo ""
 				pkg="${filename#repos/*/packages/}"
 				pkg="${pkg%%/*}"
 				echo "***    |   uninstall '$pkg'"
 				spack uninstall --all --dependents -y "$pkg"
 				;;
 			spack|config/*)
-				echo "***    |   spack was changed, needing to wipe everything"
-				( cd "$FS_TEST_INSTALLTREE" && \
-					find . -mindepth 1 -maxdepth 2 -depth \
-						-type d -print0 \
-						| xargs -0 -n 1 -t rm -rf )
+				echo ""
+				echo "***    |   spack was changed, needing to wipe"
+				wipe_install_tree
 				;;
 			env/*.yaml|Jenkinsfile|CMakeLists.txt|*.cmake|test/*)
-				echo "***    |   Ignoring"
+				echo " : Ignoring"
+				;;
+			README.md|docs/*)
+				echo " : Ignoring"
 				;;
 			*)
+				echo ""
 				echo "***    |   /!\ Don't know about this one"
 				;;
 		esac
 	done
+}
+
+function showhist() {
+	echo "***    |"
+	git log --graph --pretty="tformat:%<|(15)%h %<(50,trunc)%s" \
+	       "$1" "$2" "$(git merge-base "$1" "$2")^!" \
+	       | sed -e 's/^/***    |  /'
+	echo "***    |"
 }
 
 
@@ -45,6 +64,7 @@ echo "*** Checking changes and deleting out-dated packages"
 if [ -n "$CHANGE_ID" -a -n "$CHANGE_TARGET" ]
 then
 	echo "***    Comparing origin/$CHANGE_TARGET to HEAD"
+	showhist "origin/$CHANGE_TARGET" HEAD
 	git diff --name-only -z "origin/$CHANGE_TARGET" HEAD -- \
 		| handle_gitdifflist
 fi
@@ -55,6 +75,18 @@ then
 	| while read sha1
 	do
 		echo "***    Comparing $sha1 to worktree"
+		if git rev-parse --verify "${sha1}^{object}" >/dev/null
+		then
+			:
+		else
+			echo "***    |"
+			echo "***    |   /!\  Unknown commit hash, could mean broken install tree"
+			echo "***    |"
+			wipe_install_tree
+			echo "***    |   Stopping analyzing"
+			break
+		fi
+		showhist "${sha1}" HEAD
 		git diff --name-only -z "$sha1" \
 			| handle_gitdifflist
 	done


### PR DESCRIPTION
fixes #326 

* Backported the fix from spack/spack#18124 to our spack
* Switch to that version in our spack.
* CI: Handle unresolvable SHA-1 in install tree stamps