### PR TITLE
pythia8: version 8300 dropped --enable-shared

### DIFF
--- a/repos/fairsoft/packages/pythia8/package.py
+++ b/repos/fairsoft/packages/pythia8/package.py
@@ -40,8 +40,9 @@ class Pythia8(AutotoolsPackage):
         cfl = ' '.join(spec.compiler_flags['cxxflags'])
 
         args = ['--with-hepmc2=%s' % spec['hepmc'].prefix,
-                '--cxx-common=%s' % cfl,
-                '--enable-shared']
+                '--cxx-common=%s' % cfl]
+        if self.spec.satisfies('@:8299'):
+            args.append('--enable-shared')
         return args
 
     def setup_environment(self, spack_env, run_env):


### PR DESCRIPTION
Starting with version 8300, --enable-shared is not any more supported by ./configure. It's just "the default".

So only pass --enable-shared for all versions below.

Noticed by: Dennis Klein