### PR TITLE
yaml-cpp: shared library building; msgpack-c: checksums

### DIFF
--- a/repos/fairsoft-backports/packages/msgpack-c/package.py
+++ b/repos/fairsoft-backports/packages/msgpack-c/package.py
@@ -11,10 +11,10 @@ class MsgpackC(CMakePackage):
     homepage = "http://www.msgpack.org"
     url      = "https://github.com/msgpack/msgpack-c/archive/cpp-3.0.1.tar.gz"
 
-    version('3.1.1', '977c85b4f76c7b8d28e348552713d8ef')
-    version('3.0.1', 'a79f05f0dc5637c161805d6c0e9bfbe7')
-    version('2.1.5', '6536e2072a1006e2004e2963081692a2')
-    version('1.4.1', 'e2fd3a7419b9bc49e5017fdbefab87e0')
+    version('3.1.1', sha256='bda49f996a73d2c6080ff0523e7b535917cd28c8a79c3a5da54fc29332d61d1e')
+    version('3.0.1', sha256='1b834ab0b5b41da1dbfb96dd4a673f6de7e79dbd7f212f45a553ff9cc54abf3b')
+    version('2.1.5', sha256='9c87f80fc651b900772deaef0ab154b63160c74d292529b5be6d06d6485d4640')
+    version('1.4.1', sha256='74324d696f9abb75d8a7cd5e77add5062592b7eac386c8102de78a6cc5309886')
 
     depends_on('cmake@2.8.12:', type='build')
     depends_on('googletest', type='test')

--- a/repos/fairsoft-backports/packages/yaml-cpp/package.py
+++ b/repos/fairsoft-backports/packages/yaml-cpp/package.py
@@ -1,0 +1,77 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.spec import ConflictsInSpecError
+
+
+yaml_cpp_tests_libcxx_error_msg = 'yaml-cpp tests incompatible with libc++'
+
+
+class YamlCpp(CMakePackage):
+    """A YAML parser and emitter in C++"""
+
+    homepage = "https://github.com/jbeder/yaml-cpp"
+    url      = "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.5.3.tar.gz"
+    git      = "https://github.com/jbeder/yaml-cpp.git"
+
+    version('develop', branch='master')
+    version('0.6.3', sha256='77ea1b90b3718aa0c324207cb29418f5bced2354c2e483a9523d98c3460af1ed')
+    version('0.6.2', sha256='e4d8560e163c3d875fd5d9e5542b5fd5bec810febdcba61481fe5fc4e6b1fd05')
+    version('0.5.3', sha256='decc5beabb86e8ed9ebeb04358d5363a5c4f72d458b2c788cb2f3ac9c19467b2')
+    version('0.3.0', sha256='ab8d0e07aa14f10224ed6682065569761f363ec44bc36fcdb2946f6d38fe5a89')
+
+    variant('shared', default=True,
+            description='Build shared instead of static libraries')
+    variant('pic',   default=True,
+            description='Build with position independent code')
+    variant('tests', default=False,
+            description='Build yaml-cpp tests using internal gtest')
+
+    depends_on('boost@:1.66.99', when='@0.5.0:0.5.3')
+
+    conflicts('%gcc@:4.7', when='@0.6.0:', msg="versions 0.6.0: require c++11 support")
+    conflicts('%clang@:3.3.0', when='@0.6.0:', msg="versions 0.6.0: require c++11 support")
+    conflicts('%apple-clang@:4.0.0', when='@0.6.0:', msg="versions 0.6.0: require c++11 support")
+    conflicts('%intel@:11.1', when='@0.6.0:', msg="versions 0.6.0: require c++11 support")
+    conflicts('%xl@:13.1', when='@0.6.0:', msg="versions 0.6.0: require c++11 support")
+    conflicts('%xl_r@:13.1', when='@0.6.0:', msg="versions 0.6.0: require c++11 support")
+    conflicts('%clang cxxflags="-stdlib=libc++"', when='+tests',
+              msg=yaml_cpp_tests_libcxx_error_msg)
+
+    def flag_handler(self, name, flags):
+        # We cannot catch all conflicts with the conflicts directive because
+        # the user can add arbitrary strings to the flags. Here we can at least
+        # fail early.
+        # We'll include cppflags in case users mistakenly put c++ flags there.
+        spec = self.spec
+        if name in ('cxxflags', 'cppflags') and spec.satisfies('+tests'):
+            if '-stdlib=libc++' in flags:
+                raise ConflictsInSpecError(
+                    spec,
+                    [(spec,
+                      spec.compiler_flags[name],
+                      spec.variants['tests'],
+                      yaml_cpp_tests_libcxx_error_msg)]
+                )
+        return (flags, None, None)
+
+    def cmake_args(self):
+        options = []
+
+        options.extend([
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('YAML_BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'),
+            self.define_from_variant('YAML_CPP_BUILD_TESTS', 'tests'),
+        ])
+
+        return options
+
+    def url_for_version(self, version):
+        url = "https://github.com/jbeder/yaml-cpp/archive/{0}-{1}.tar.gz"
+        if version < Version('0.5.3'):
+            return url.format('release', version)
+        else:
+            return url.format('yaml-cpp', version)


### PR DESCRIPTION
* yaml-cpp: Backport from upstream (shared library)

  Fix shared library building of yaml-cpp

  See: https://github.com/FairRootGroup/FairSoft/commit/7778fcb23bd525be18cfd2
  See: https://github.com/spack/spack/pull/19866

* msgpack-c: Switch checksums to sha256