### PR TITLE
[spack] Bump clhep@2.4.4.0, geant4@10.7, geant4-vmc@5-3

### DIFF
--- a/env/dev/sim/spack.yaml
+++ b/env/dev/sim/spack.yaml
@@ -9,12 +9,12 @@ spack:
   - pythia6@428-alice1
   - hepmc@2.06.11 length=CM momentum=GEV
   - pythia8@8303
-  - geant4@10.6.2~qt~vecgeom~opengl~x11~motif~threads
+  - geant4@10.7.0~qt~vecgeom~opengl~x11~motif~threads
   - $root
   - vmc@1-0-p3
   - geant3@3.7
   - vgm@4-8
-  - geant4-vmc@5-2
+  - geant4-vmc@5-3
   - fairroot@18.4.1+sim+examples
   - odc
   concretization: together

--- a/env/dev/sim_mt/spack.yaml
+++ b/env/dev/sim_mt/spack.yaml
@@ -9,12 +9,12 @@ spack:
   - pythia6@428-alice1
   - hepmc@2.06.11 length=CM momentum=GEV
   - pythia8@8303
-  - geant4@10.6.2~qt~vecgeom~opengl~x11~motif+threads
+  - geant4@10.7.0~qt~vecgeom~opengl~x11~motif+threads
   - $root
   - vmc@1-0-p3
   - geant3@3.7
   - vgm@4-8
-  - geant4-vmc@5-2
+  - geant4-vmc@5-3
   - fairroot@18.4.1+sim+examples
   - odc
   concretization: together

--- a/env/dev/sim_mt_headless/spack.yaml
+++ b/env/dev/sim_mt_headless/spack.yaml
@@ -8,12 +8,12 @@ spack:
   - pythia6@428-alice1
   - hepmc@2.06.11 length=CM momentum=GEV
   - pythia8@8303
-  - geant4@10.6.2~qt~vecgeom~opengl~x11~motif+threads
+  - geant4@10.7.0~qt~vecgeom~opengl~x11~motif+threads
   - $root
   - vmc@1-0-p3
   - geant3@3.7
   - vgm@4-8
-  - geant4-vmc@5-2
+  - geant4-vmc@5-3
   - fairroot@18.4.1+sim+examples
   - odc
   concretization: together

--- a/repos/fairsoft-backports/packages/clhep/darwin/CLHEP.patch
+++ b/repos/fairsoft-backports/packages/clhep/darwin/CLHEP.patch
@@ -1,0 +1,11 @@
+--- CLHEP/CMakeLists.txt	2016-06-20 14:41:12.000000000 -0500
++++ CLHEP/CMakeLists.txt	2016-06-20 14:40:57.000000000 -0500
+@@ -37,7 +37,7 @@
+ # If Policy CMP0042 exists, use OLD to prefer the use of install names
+ # instead of the new @rpath default. 
+ if(POLICY CMP0042)
+-  cmake_policy(SET CMP0042 NEW)
++  cmake_policy(SET CMP0042 OLD)
+ endif()
+ 
+ set(CMAKE_MODULE_PATH 

--- a/repos/fairsoft-backports/packages/clhep/package.py
+++ b/repos/fairsoft-backports/packages/clhep/package.py
@@ -1,0 +1,66 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Clhep(CMakePackage):
+    """CLHEP is a C++ Class Library for High Energy Physics. """
+    homepage = "http://proj-clhep.web.cern.ch/proj-clhep/"
+    url      = "http://proj-clhep.web.cern.ch/proj-clhep/dist1/clhep-2.4.1.3.tgz"
+    list_url = "https://proj-clhep.web.cern.ch/proj-clhep/"
+    list_depth = 1
+
+    tags = ['hep']
+
+    maintainers = ['drbenmorgan']
+
+    version('2.4.4.0', sha256='5df78c11733a091da9ae5a24ce31161d44034dd45f20455587db85f1ca1ba539')
+    version('2.4.1.3', sha256='27c257934929f4cb1643aa60aeaad6519025d8f0a1c199bc3137ad7368245913')
+    version('2.4.1.2', sha256='ff96e7282254164380460bc8cf2dff2b58944084eadcd872b5661eb5a33fa4b8')
+    version('2.4.1.0', sha256='d14736eb5c3d21f86ce831dc1afcf03d423825b35c84deb6f8fd16773528c54d')
+    version('2.4.0.4', sha256='eb013841c57990befa1e977a11a552ab8328733c1c3b6cecfde86da40dc22113')
+    version('2.4.0.2', sha256='1e9891c5badb718c24933e7a5c6ee4d64fd4d5cf3a40c150ad18e864ec86b8a4')
+    version('2.4.0.1', sha256='4c7e2c6ac63e0237100e4ddcbfdc3d7e7dc6592f95bdbdcc0e43a6892b9fd6e0')
+    version('2.4.0.0', sha256='5e5cf284323898b4c807db6e684d65d379ade65fe0e93f7b10456890a6dee8cc')
+    version('2.3.4.6', sha256='3e53947036f8570c7a08bed670a862426dbca17328afcecd6c875d8487fef204')
+    version('2.3.4.5', sha256='1199d04626cb8bc1307e282b143018691077cc61fe2f286a382030262eda8764')
+    version('2.3.4.4', sha256='e54de15ffa5108a1913c4910845436345c89ddb83480cd03277a795fafabfb9d')
+    version('2.3.4.3', sha256='1019479265f956bd660c11cb439e1443d4fd1655e8d51accf8b1e703e4262dff')
+    version('2.3.4.2', sha256='6d1e15ccbe1ca6e71d541e78ca7e8c9f3d986ee0da5177a4b8cda00c619dc691')
+    version('2.3.3.2', sha256='4e69a5afb1b7ecc435395195140afc85bbbb9f4d3572f59451c3882f3015a7c1')
+    version('2.3.3.1', sha256='cd74bfae4773620dd0c7cc9c1696a08386931d7e47a3906aa632cc5cb44ed6bd')
+    version('2.3.3.0', sha256='0bcae1bed8d3aa4256e3a553a4f60484312f2121dcc83492a40f08a70881c8c0')
+    version('2.3.2.2', sha256='885481ae32c2f31c3b7f14a5e5d68bc56dc3df0c597be464d7ffa265b8a5a1af')
+    version('2.3.1.1', sha256='0e2b170df99176feb0aa4f20ea3b33463193c086682749790c5b9b79388d0ff4')
+    version('2.3.1.0', sha256='66272ae3100d3aec096b1298e1e24ec25b80e4dac28332b45ec3284023592963')
+    version('2.3.0.0', sha256='63e77f4f34baa5eaa0adb1ca2438734f2d6f5ca112d830650dd005a6109f2397')
+    version('2.2.0.8', sha256='f735e236b1f023ba7399269733b2e84eaed4de615081555b1ab3af25a1e92112')
+    version('2.2.0.5', sha256='92e8b5d32ae96154edd27d0c641ba048ad33cb69dd4f1cfb72fc578770a34818')
+    version('2.2.0.4', sha256='9bf7fcd9892313c8d1436bc4a4a285a016c4f8e81e1fc65bdf6783207ae57550')
+
+    variant('cxxstd',
+            default='11',
+            values=('11', '14', '17'),
+            multi=False,
+            description='Use the specified C++ standard when building.')
+
+    conflicts('cxxstd=17', when='@:2.3.4.2')
+
+    depends_on('cmake@2.8.12.2:', when='@2.2.0.4:2.3.0.0', type='build')
+    depends_on('cmake@3.2:', when='@2.3.0.1:', type='build')
+
+    root_cmakelists_dir = 'CLHEP'  # Extra directory layer.
+
+    def patch(self):
+        filter_file('SET CMP0042 OLD',
+                    'SET CMP0042 NEW',
+                    '%s/CLHEP/CMakeLists.txt' % self.stage.source_path)
+
+    def cmake_args(self):
+        cmake_args = ['-DCLHEP_BUILD_CXXSTD=-std=c++{0}'.format(
+                      self.spec.variants['cxxstd'].value)]
+        return cmake_args

--- a/repos/fairsoft-backports/packages/g4emlow/package.py
+++ b/repos/fairsoft-backports/packages/g4emlow/package.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class G4emlow(Package):
+    """Geant4 data files for low energy electromagnetic processes."""
+    homepage = "http://geant4.web.cern.ch"
+    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4EMLOW.6.50.tar.gz"
+
+    tags = ['hep']
+
+    maintainers = ['drbenmorgan']
+
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('7.13', sha256='374896b649be776c6c10fea80abe6cf32f9136df0b6ab7c7236d571d49fb8c69')
+    version('7.9.1', sha256='820c106e501c64c617df6c9e33a0f0a3822ffad059871930f74b8cc37f043ccb')
+    version('7.9', sha256='4abf9aa6cda91e4612676ce4d2d8a73b91184533aa66f9aad19a53a8c4dc3aff')
+    version('7.7', sha256='16dec6adda6477a97424d749688d73e9bd7d0b84d0137a67cf341f1960984663')
+    version('7.3', sha256='583aa7f34f67b09db7d566f904c54b21e95a9ac05b60e2bfb794efb569dba14e')
+    version('6.50', sha256='c97be73fece5fb4f73c43e11c146b43f651c6991edd0edf8619c9452f8ab1236')
+
+    def install(self, spec, prefix):
+        mkdirp(join_path(prefix.share, 'data'))
+        install_path = join_path(prefix.share, 'data', 'G4EMLOW{0}'
+                                 .format(self.version))
+        install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(self.prefix.share, 'data', 'G4EMLOW{0}'
+                                 .format(self.version))
+        env.set('G4LEDATA', install_path)
+
+    def url_for_version(self, version):
+        """Handle version string."""
+        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4EMLOW.%s.tar.gz" % version)

--- a/repos/fairsoft-backports/packages/g4ensdfstate/package.py
+++ b/repos/fairsoft-backports/packages/g4ensdfstate/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class G4ensdfstate(Package):
+    """Geant4 data for nuclides properties"""
+    homepage = "http://geant4.web.cern.ch"
+    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4ENSDFSTATE.2.1.tar.gz"
+
+    tags = ['hep']
+
+    maintainers = ['drbenmorgan']
+
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('2.3', sha256='9444c5e0820791abd3ccaace105b0e47790fadce286e11149834e79c4a8e9203')
+    version('2.2', sha256='dd7e27ef62070734a4a709601f5b3bada6641b111eb7069344e4f99a01d6e0a6')
+    version('2.1', sha256='933e7f99b1c70f24694d12d517dfca36d82f4e95b084c15d86756ace2a2790d9')
+
+    def install(self, spec, prefix):
+        mkdirp(join_path(prefix.share, 'data'))
+        install_path = join_path(prefix.share, 'data', 'G4ENSDFSTATE{0}'
+                                 .format(self.version))
+        install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(self.prefix.share, 'data', 'G4ENSDFSTATE{0}'
+                                 .format(self.version))
+        env.set('G4ENSDFSTATEDATA', install_path)
+
+    def url_for_version(self, version):
+        """Handle version string."""
+        return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4ENSDFSTATE.%s.tar.gz" % version

--- a/repos/fairsoft-backports/packages/g4particlexs/package.py
+++ b/repos/fairsoft-backports/packages/g4particlexs/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class G4particlexs(Package):
+    """Geant4 data for evaluated particle cross-sections on
+    natural composition of elements"""
+    homepage = "http://geant4.web.cern.ch"
+    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4PARTICLEXS.2.1.tar.gz"
+
+    tags = ['hep']
+
+    maintainers = ['drbenmorgan']
+
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('3.1', sha256='404da84ead165e5cccc0bb795222f6270c9bf491ef4a0fd65195128b27f0e9cd')
+    version('2.1', sha256='094d103372bbf8780d63a11632397e72d1191dc5027f9adabaf6a43025520b41')
+    version('1.1', sha256='100a11c9ed961152acfadcc9b583a9f649dda4e48ab314fcd4f333412ade9d62')
+
+    def install(self, spec, prefix):
+        mkdirp(join_path(prefix.share, 'data'))
+        install_path = join_path(prefix.share, 'data', "G4PARTICLEXS{0}"
+                                 .format(self.version))
+        install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(self.prefix.share, 'data', 'G4PARTICLEXS{0}'
+                                 .format(self.version))
+        env.set('G4PARTICLEXSDATA', install_path)
+
+    def url_for_version(self, version):
+        """Handle version string."""
+        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4PARTICLEXS.%s.tar.gz" % version)

--- a/repos/fairsoft-backports/packages/g4photonevaporation/package.py
+++ b/repos/fairsoft-backports/packages/g4photonevaporation/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class G4photonevaporation(Package):
+    """Geant4 data for photon evaporation"""
+    homepage = "http://geant4.web.cern.ch"
+    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4PhotonEvaporation.4.3.2.tar.gz"
+
+    tags = ['hep']
+
+    maintainers = ['drbenmorgan']
+
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('5.7', sha256='761e42e56ffdde3d9839f9f9d8102607c6b4c0329151ee518206f4ee9e77e7e5')
+    version('5.5', sha256='5995dda126c18bd7f68861efde87b4af438c329ecbe849572031ceed8f5e76d7')
+    version('5.3', sha256='d47ababc8cbe548065ef644e9bd88266869e75e2f9e577ebc36bc55bf7a92ec8')
+    version('5.2', sha256='83607f8d36827b2a7fca19c9c336caffbebf61a359d0ef7cee44a8bcf3fc2d1f')
+    version('4.3.2', sha256='d4641a6fe1c645ab2a7ecee09c34e5ea584fb10d63d2838248bfc487d34207c7')
+
+    def install(self, spec, prefix):
+        mkdirp(join_path(prefix.share, 'data'))
+        install_path = join_path(prefix.share, 'data',
+                                 'PhotonEvaporation{0}'
+                                 .format(self.version))
+        install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(self.prefix.share, 'data',
+                                 'PhotonEvaporation{0}'
+                                 .format(self.version))
+        env.set('G4LEVELGAMMADATA', install_path)
+
+    def url_for_version(self, version):
+        """Handle version string."""
+        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4PhotonEvaporation.%s.tar.gz" % version)

--- a/repos/fairsoft-backports/packages/g4radioactivedecay/package.py
+++ b/repos/fairsoft-backports/packages/g4radioactivedecay/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class G4radioactivedecay(Package):
+    """Geant4 data files for radio-active decay hadronic processes"""
+    homepage = "http://geant4.web.cern.ch"
+    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4RadioactiveDecay.5.1.1.tar.gz"
+
+    tags = ['hep']
+
+    maintainers = ['drbenmorgan']
+
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('5.6', sha256='3886077c9c8e5a98783e6718e1c32567899eeb2dbb33e402d4476bc2fe4f0df1')
+    version('5.4', sha256='240779da7d13f5bf0db250f472298c3804513e8aca6cae301db97f5ccdcc4a61')
+    version('5.3', sha256='5c8992ac57ae56e66b064d3f5cdfe7c2fee76567520ad34a625bfb187119f8c1')
+    version('5.2', sha256='99c038d89d70281316be15c3c98a66c5d0ca01ef575127b6a094063003e2af5d')
+    version('5.1.1', sha256='f7a9a0cc998f0d946359f2cb18d30dff1eabb7f3c578891111fc3641833870ae')
+
+    def install(self, spec, prefix):
+        mkdirp(join_path(prefix.share, 'data'))
+        install_path = join_path(prefix.share, 'data',
+                                 'RadioactiveDecay{0}'
+                                 .format(self.version))
+        install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(self.prefix.share, 'data',
+                                 'RadioactiveDecay{0}'
+                                 .format(self.version))
+        env.set('G4RADIOACTIVEDATA', install_path)
+
+    def url_for_version(self, version):
+        """Handle version string."""
+        return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4RadioactiveDecay.%s.tar.gz" % version)

--- a/repos/fairsoft-backports/packages/g4realsurface/package.py
+++ b/repos/fairsoft-backports/packages/g4realsurface/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class G4realsurface(Package):
+    """Geant4 data for measured optical surface reflectance"""
+    homepage = "http://geant4.web.cern.ch"
+    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/RealSurface.1.0.tar.gz"
+
+    tags = ['hep']
+
+    maintainers = ['drbenmorgan']
+
+    # Only versions relevant to Geant4 releases built by spack are added
+    version('2.2', sha256='9954dee0012f5331267f783690e912e72db5bf52ea9babecd12ea22282176820')
+    version('2.1.1', sha256='90481ff97a7c3fa792b7a2a21c9ed80a40e6be386e581a39950c844b2dd06f50')
+    version('2.1', sha256='2a287adbda1c0292571edeae2082a65b7f7bd6cf2bf088432d1d6f889426dcf3')
+    version('1.0', sha256='3e2d2506600d2780ed903f1f2681962e208039329347c58ba1916740679020b1')
+
+    def install(self, spec, prefix):
+        mkdirp(join_path(prefix.share, 'data'))
+        install_path = join_path(prefix.share, 'data', 'RealSurface{0}'
+                                 .format(self.version))
+        install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(self.prefix.share, 'data', 'RealSurface{0}'
+                                 .format(self.version))
+        env.set('G4REALSURFACEDATA', install_path)
+
+    def url_for_version(self, version):
+        """Handle version string."""
+        return "http://geant4-data.web.cern.ch/geant4-data/datasets/{0}RealSurface.{1}.tar.gz".format(
+            "G4" if version > Version('1.0') else "", version)

--- a/repos/fairsoft-backports/packages/geant4-data/package.py
+++ b/repos/fairsoft-backports/packages/geant4-data/package.py
@@ -1,0 +1,116 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import os
+import glob
+
+
+class Geant4Data(BundlePackage):
+    """A bundle package to hold Geant4 data packages"""
+
+    homepage = "http://geant4.cern.ch"
+
+    maintainers = ['drbenmorgan']
+
+    tags = ['hep']
+
+    version('10.7.0')
+    version('10.6.3')
+    version('10.6.2')
+    version('10.6.1')
+    version('10.6.0')
+    version('10.5.1')
+    version('10.4.3')
+    version('10.4.0')
+    version('10.3.3')
+
+    # Add install phase so we can create the data "view"
+    phases = ['install']
+
+    # For clarity, declare deps on a Major-Minor version basis as
+    # they generally don't change on the patch level
+    # Can move to declaring on a dataset basis if needed
+    # geant4@10.7.X
+    depends_on("g4ndl@4.6", when='@10.7.0:10.7.9999')
+    depends_on("g4emlow@7.13", when='@10.7.0:10.7.9999')
+    depends_on("g4photonevaporation@5.7", when='@10.7.0:10.7.9999')
+    depends_on("g4radioactivedecay@5.6", when='@10.7.0:10.7.9999')
+    depends_on("g4particlexs@3.1", when='@10.7.0:10.7.9999')
+    depends_on("g4pii@1.3", when='@10.7.0:10.7.9999')
+    depends_on("g4realsurface@2.2", when='@10.7.0:10.7.9999')
+    depends_on("g4saiddata@2.0", when='@10.7.0:10.7.9999')
+    depends_on("g4abla@3.1", when='@10.7.0:10.7.9999')
+    depends_on("g4incl@1.0", when='@10.7.0:10.7.9999')
+    depends_on("g4ensdfstate@2.3", when='@10.7.0:10.7.9999')
+
+    # geant4@10.6.X
+    depends_on("g4ndl@4.6", when='@10.6.0:10.6.9999')
+    depends_on("g4emlow@7.9", when='@10.6.0')
+    depends_on("g4emlow@7.9.1", when='@10.6.1:10.6.9999')
+    depends_on("g4photonevaporation@5.5", when='@10.6.0:10.6.9999')
+    depends_on("g4radioactivedecay@5.4", when='@10.6.0:10.6.9999')
+    depends_on("g4particlexs@2.1", when='@10.6.0:10.6.9999')
+    depends_on("g4pii@1.3", when='@10.6.0:10.6.9999')
+    depends_on("g4realsurface@2.1.1", when='@10.6.0:10.6.9999')
+    depends_on("g4saiddata@2.0", when='@10.6.0:10.6.9999')
+    depends_on("g4abla@3.1", when='@10.6.0:10.6.9999')
+    depends_on("g4incl@1.0", when='@10.6.0:10.6.9999')
+    depends_on("g4ensdfstate@2.2", when='@10.6.0:10.6.9999')
+
+    # geant4@10.5.X
+    depends_on("g4ndl@4.5", when='@10.5.0:10.5.9999')
+    depends_on("g4emlow@7.7", when='@10.5.0:10.5.9999')
+    depends_on("g4photonevaporation@5.3", when='@10.5.0:10.5.9999')
+    depends_on("g4radioactivedecay@5.3", when='@10.5.0:10.5.9999')
+    depends_on("g4particlexs@1.1", when='@10.5.0:10.5.9999')
+    depends_on("g4pii@1.3", when='@10.5.0:10.5.9999')
+    depends_on("g4realsurface@2.1.1", when='@10.5.0:10.5.9999')
+    depends_on("g4saiddata@2.0", when='@10.5.0:10.5.9999')
+    depends_on("g4abla@3.1", when='@10.5.0:10.5.9999')
+    depends_on("g4incl@1.0", when='@10.5.0:10.5.9999')
+    depends_on("g4ensdfstate@2.2", when='@10.5.0:10.5.9999')
+
+    # geant4@10.4.X
+    depends_on("g4ndl@4.5", when='@10.4.0:10.4.9999')
+    depends_on("g4emlow@7.3", when='@10.4.0:10.4.9999')
+    depends_on("g4photonevaporation@5.2", when='@10.4.0:10.4.9999')
+    depends_on("g4radioactivedecay@5.2", when='@10.4.0:10.4.9999')
+    depends_on("g4neutronxs@1.4", when='@10.4.0:10.4.9999')
+    depends_on("g4pii@1.3", when='@10.4.0:10.4.9999')
+
+    depends_on("g4realsurface@2.1.1", when='@10.4.2:10.4.9999')
+    depends_on("g4realsurface@2.1", when='@10.4.0:10.4.1')
+
+    depends_on("g4saiddata@1.1", when='@10.4.0:10.4.9999')
+    depends_on("g4abla@3.1", when='@10.4.0:10.4.9999')
+    depends_on("g4ensdfstate@2.2", when='@10.4.0:10.4.9999')
+
+    # geant4@10.3.X
+    depends_on("g4ndl@4.5", when='@10.3.0:10.3.9999')
+    depends_on("g4emlow@6.50", when='@10.3.0:10.3.9999')
+
+    depends_on("g4photonevaporation@4.3.2", when='@10.3.1:10.3.9999')
+    depends_on("g4photonevaporation@4.3", when='@10.3.0')
+
+    depends_on("g4radioactivedecay@5.1.1", when='@10.3.1:10.3.9999')
+    depends_on("g4radioactivedecay@5.1", when='@10.3.0')
+
+    depends_on("g4neutronxs@1.4", when='@10.3.0:10.3.9999')
+    depends_on("g4pii@1.3", when='@10.3.0:10.3.9999')
+    depends_on("g4realsurface@1.0", when='@10.3.0:10.3.9999')
+    depends_on("g4saiddata@1.1", when='@10.3.0:10.3.9999')
+    depends_on("g4abla@3.0", when='@10.3.0:10.3.9999')
+    depends_on("g4ensdfstate@2.1", when='@10.3.0:10.3.9999')
+
+    def install(self, spec, prefix):
+        spec = self.spec
+        data = '{0}-{1}'.format(self.name, self.version.dotted)
+        datadir = join_path(spec.prefix.share, data)
+
+        with working_dir(datadir, create=True):
+            for s in spec.dependencies():
+                for d in glob.glob('{0}/data/*'.format(s.prefix.share)):
+                    os.symlink(d, os.path.basename(d))

--- a/repos/fairsoft-backports/packages/geant4/CLHEP-10.03.03.patch
+++ b/repos/fairsoft-backports/packages/geant4/CLHEP-10.03.03.patch
@@ -1,0 +1,34 @@
+diff --git a/cmake/Modules/FindCLHEP.cmake b/cmake/Modules/FindCLHEP.cmake
+index 8b59f1c0a..f616d678e 100644
+--- a/cmake/Modules/FindCLHEP.cmake
++++ b/cmake/Modules/FindCLHEP.cmake
+@@ -180,7 +180,10 @@ if(UNIX)
+         execute_process(COMMAND ${CLHEP_CONFIG_EXECUTABLE} --prefix
+             OUTPUT_VARIABLE _clhep_config_prefix
+             OUTPUT_STRIP_TRAILING_WHITESPACE)
+-
++          if (_clhep_config_prefix)
++            # Remove wrapping double quotes.
++            string(REGEX REPLACE "\"(.*)\"" "\\1" _clhep_config_prefix "${_clhep_config_prefix}")
++          endif()
+         list(APPEND _clhep_root_hints ${_clhep_config_prefix})
+     endif()
+ elseif(WIN32 AND NOT UNIX)
+diff --git a/cmake/Templates/Geant4Config.cmake.in b/cmake/Templates/Geant4Config.cmake.in
+index d6fe408b3..f355be2af 100644
+--- a/cmake/Templates/Geant4Config.cmake.in
++++ b/cmake/Templates/Geant4Config.cmake.in
+@@ -268,13 +268,7 @@ set(Geant4_builtin_clhep_FOUND @GEANT4_USE_BUILTIN_CLHEP@)
+ if(NOT Geant4_builtin_clhep_FOUND)
+   set(Geant4_system_clhep_ISGRANULAR @GEANT4_USE_SYSTEM_CLHEP_GRANULAR@)
+ 
+-  set(CLHEP_ROOT_DIR "@CLHEP_ROOT_DIR@")
+-  set(__GEANT4_OLD_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
+-  set(CMAKE_MODULE_PATH "${_geant4_thisdir}/Modules" ${CMAKE_MODULE_PATH})
+   find_package(CLHEP @CLHEP_VERSION@ REQUIRED @__g4_clhep_components@)
+-  set(CMAKE_MODULE_PATH ${__GEANT4_OLD_CMAKE_MODULE_PATH})
+-  unset(CLHEP_ROOT_DIR)
+-  unset(__GEANT4_OLD_CMAKE_MODULE_PATH)
+   #CLHEP doesn't use target properties fully yet, so always include_directories
+   include_directories(${CLHEP_INCLUDE_DIRS})
+ endif()

--- a/repos/fairsoft-backports/packages/geant4/cxx17.patch
+++ b/repos/fairsoft-backports/packages/geant4/cxx17.patch
@@ -1,0 +1,22 @@
+diff -Naur geant4.10.03.p03/cmake/Modules/Geant4LibraryBuildOptions.cmake geant4.10.03.p03/cmake/Modules/Geant4LibraryBuildOptions.cmake
+--- geant4.10.03.p03/cmake/Modules/Geant4LibraryBuildOptions.cmake	2017-10-20 06:30:46.000000000 -0500
++++ geant4.10.03.p03/cmake/Modules/Geant4LibraryBuildOptions.cmake	2018-04-16 16:48:02.194321171 -0500
+@@ -76,7 +76,7 @@
+ # Mark as advanced because most users will not need it
+ enum_option(GEANT4_BUILD_CXXSTD
+   DOC "C++ Standard to compile against"
+-  VALUES 11 14 c++11 c++14
++  VALUES 11 14 17 c++11 c++14 c++17
+   CASE_INSENSITIVE
+   )
+ 
+@@ -106,6 +106,9 @@
+ 
+ # Add Definition to flags for temporary back compatibility
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DG4USE_STD11")
++if(GEANT4_BUILD_CXXSTD GREATER 14)
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES=1")
++endif()
+ 
+ # Hold any appropriate compile flag(s) in variable for later export to
+ # config files. Needed to support late CMake 2.8 where compile features

--- a/repos/fairsoft-backports/packages/geant4/cxx17_geant4_10_0.patch
+++ b/repos/fairsoft-backports/packages/geant4/cxx17_geant4_10_0.patch
@@ -1,0 +1,22 @@
+diff -Naur geant4/cmake/Modules/G4BuildSettings.cmake geant4/cmake/Modules/G4BuildSettings.cmake
+--- geant4/cmake/Modules/G4BuildSettings.cmake	2017-10-20 06:30:46.000000000 -0500
++++ geant4/cmake/Modules/G4BuildSettings.cmake	2018-04-16 16:48:02.194321171 -0500
+@@ -76,7 +76,7 @@
+ # Mark as advanced because most users will not need it
+ enum_option(GEANT4_BUILD_CXXSTD
+   DOC "C++ Standard to compile against"
+-  VALUES 11 14 c++11 c++14
++  VALUES 11 14 17 c++11 c++14 c++17
+   CASE_INSENSITIVE
+   )
+ 
+@@ -106,6 +106,9 @@
+ 
+ # Add Definition to flags for temporary back compatibility
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DG4USE_STD11")
++if(GEANT4_BUILD_CXXSTD GREATER 14)
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES=1")
++endif()
+ 
+ # Hold any appropriate compile flag(s) in variable for later export to
+ # config files. Needed to support late CMake 2.8 where compile features

--- a/repos/fairsoft-backports/packages/geant4/geant4-10.4.3-cxx17-removed-features.patch
+++ b/repos/fairsoft-backports/packages/geant4/geant4-10.4.3-cxx17-removed-features.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/Modules/G4BuildSettings.cmake b/cmake/Modules/G4BuildSettings.cmake
+index f68cb0a44..6bf4b6948 100644
+--- a/cmake/Modules/G4BuildSettings.cmake
++++ b/cmake/Modules/G4BuildSettings.cmake
+@@ -205,6 +205,13 @@ endif()
+ # Add Definition to flags for temporary back compatibility
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DG4USE_STD11")
+ 
++# Spack patch to support use of C++ features deprecated/removed in C++17
++# Only checked on AppleClang for now
++if(GEANT4_BUILD_CXXSTD GREATER 14)
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES=1")
++endif()
++#----
++
+ # Hold any appropriate compile flag(s) in variable for later export to
+ # config files. Needed to support clients using late CMake 2.8 where compile features
+ # are not available.

--- a/repos/fairsoft-backports/packages/geant4/package.py
+++ b/repos/fairsoft-backports/packages/geant4/package.py
@@ -1,0 +1,174 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Geant4(CMakePackage):
+    """Geant4 is a toolkit for the simulation of the passage of particles
+    through matter. Its areas of application include high energy, nuclear
+    and accelerator physics, as well as studies in medical and space
+    science."""
+
+    homepage = "http://geant4.cern.ch/"
+    url = "https://gitlab.cern.ch/geant4/geant4/-/archive/v10.6.0/geant4-v10.6.0.tar.gz"
+
+    tags = ['hep']
+
+    maintainers = ['drbenmorgan']
+
+    version('10.7.0', sha256='c991a139210c7f194720c900b149405090058c00beb5a0d2fac5c40c42a262d4')
+    version('10.6.3', sha256='bf96d6d38e6a0deabb6fb6232eb00e46153134da645715d636b9b7b4490193d3')
+    version('10.6.2', sha256='e381e04c02aeade1ed8cdd9fdbe7dcf5d6f0f9b3837a417976b839318a005dbd')
+    version('10.6.1', sha256='4fd64149ae26952672a81ce5579d3806fda4bd251d486897093ac57633a42b7e')
+    version('10.6.0', sha256='eebe6a170546064ff81ab3b00f513ccd1d4122a026514982368d503ac55a4ee4')
+    version('10.5.1', sha256='2397eb859dc4de095ff66059d8bda9f060fdc42e10469dd7890946293eeb0e39')
+    version('10.4.3', sha256='67f3bb6405a2c77e573936c2b933f5a4a33915aa379626a2eb3012009b91e1da')
+    version('10.4.0', sha256='e919b9b0a88476e00c0b18ab65d40e6a714b55ee4778f66bac32a5396c22aa74')
+    version('10.3.3', sha256='bcd36a453da44de9368d1d61b0144031a58e4b43a6d2d875e19085f2700a89d8')
+
+    _cxxstd_values = ('11', '14', '17')
+    variant('cxxstd',
+            default=_cxxstd_values[0],
+            values=_cxxstd_values,
+            multi=False,
+            description='Use the specified C++ standard when building.')
+
+    variant('threads', default=True, description='Build with multithreading')
+    variant('vecgeom', default=False, description='Enable vecgeom support')
+    variant('opengl', default=False, description='Optional OpenGL support')
+    variant('x11', default=False, description='Optional X11 support')
+    variant('motif', default=False, description='Optional motif support')
+    variant('qt', default=False, description='Enable Qt support')
+    variant('python', default=False, description='Enable Python bindings')
+
+    depends_on('cmake@3.5:', type='build')
+    depends_on('cmake@3.8:', type='build', when='@10.6.0:')
+
+    depends_on('geant4-data@10.7.0', when='@10.7.0')
+    depends_on('geant4-data@10.6.3', when='@10.6.3')
+    depends_on('geant4-data@10.6.2', when='@10.6.2')
+    depends_on('geant4-data@10.6.1', when='@10.6.1')
+    depends_on('geant4-data@10.6.0', when='@10.6.0')
+    depends_on('geant4-data@10.5.1', when='@10.5.1')
+    depends_on('geant4-data@10.4.3', when='@10.4.3')
+    depends_on('geant4-data@10.4.0', when='@10.4.0')
+    depends_on('geant4-data@10.3.3', when='@10.3.3')
+
+    depends_on("expat")
+    depends_on("zlib")
+
+    # Python, with boost requirement dealt with in cxxstd section
+    depends_on('python@3:', when='+python')
+    extends('python', when='+python')
+    conflicts('+python', when='@:10.6.1',
+              msg='Geant4 <= 10.6.1 cannot be built with Python bindings')
+
+    for std in _cxxstd_values:
+        # CLHEP version requirements to be reviewed
+        depends_on('clhep@2.4.4.0: cxxstd=' + std,
+                   when='@10.7.0: cxxstd=' + std)
+
+        depends_on('clhep@2.3.3.0: cxxstd=' + std,
+                   when='@10.3.3:10.6.99 cxxstd=' + std)
+
+        # Spack only supports Xerces-c 3 and above, so no version req
+        depends_on('xerces-c cxxstd=' + std, when='cxxstd=' + std)
+
+        # Vecgeom specific versions for each Geant4 version
+        depends_on('vecgeom@1.1.8 cxxstd=' + std,
+                   when='@10.7.0: +vecgeom cxxstd=' + std)
+        depends_on('vecgeom@1.1.5 cxxstd=' + std,
+                   when='@10.6.0:10.6.99 +vecgeom cxxstd=' + std)
+        depends_on('vecgeom@1.1.0 cxxstd=' + std,
+                   when='@10.5.0:10.5.99 +vecgeom cxxstd=' + std)
+        depends_on('vecgeom@0.5.2 cxxstd=' + std,
+                   when='@10.4.0:10.4.99 +vecgeom cxxstd=' + std)
+        depends_on('vecgeom@0.3rc cxxstd=' + std,
+                   when='@10.3.0:10.3.99 +vecgeom cxxstd=' + std)
+
+        # Boost.python, conflict handled earlier
+        depends_on('boost@1.70: +python cxxstd=' + std,
+                   when='+python cxxstd=' + std)
+
+    # Visualization driver dependencies
+    depends_on("gl", when='+opengl')
+    depends_on("glu", when='+opengl')
+    depends_on("glx", when='+opengl+x11')
+    depends_on("libx11", when='+x11')
+    depends_on("libxmu", when='+x11')
+    depends_on("motif", when='+motif')
+    depends_on("qt@5: +opengl", when="+qt")
+
+    # As released, 10.03.03 has issues with respect to using external
+    # CLHEP.
+    patch('CLHEP-10.03.03.patch', level=1, when='@10.3.3')
+    # These patches can be applied independent of the cxxstd value?
+    patch('cxx17.patch', when='@:10.3.99 cxxstd=17')
+    patch('cxx17_geant4_10_0.patch', level=1, when='@10.4.0 cxxstd=17')
+    patch('geant4-10.4.3-cxx17-removed-features.patch',
+          level=1, when='@10.4.3 cxxstd=17')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        # Core options
+        options = [
+            self.define_from_variant('GEANT4_BUILD_CXXSTD', 'cxxstd'),
+            '-DGEANT4_USE_SYSTEM_CLHEP=ON',
+            '-DGEANT4_USE_SYSTEM_EXPAT=ON',
+            '-DGEANT4_USE_SYSTEM_ZLIB=ON',
+            '-DGEANT4_USE_G3TOG4=ON',
+            '-DGEANT4_USE_GDML=ON',
+            '-DXERCESC_ROOT_DIR={0}'.format(spec['xerces-c'].prefix)
+        ]
+
+        # Don't install the package cache file as Spack will set
+        # up CMAKE_PREFIX_PATH etc for the dependencies
+        if spec.version > Version('10.5.99'):
+            options.append('-DGEANT4_INSTALL_PACKAGE_CACHE=OFF')
+
+        # Multithreading
+        options.append(self.define_from_variant('GEANT4_BUILD_MULTITHREADED',
+                                                'threads'))
+        if '+threads' in spec:
+            # Locked at global-dynamic to allow use cases that load the
+            # geant4 libs at application runtime
+            options.append('-DGEANT4_BUILD_TLS_MODEL=global-dynamic')
+
+        # install the data with geant4
+        datadir = spec['geant4-data'].prefix.share
+        dataver = '{0}-{1}'.format(spec['geant4-data'].name,
+                                   spec['geant4-data'].version.dotted)
+        datapath = join_path(datadir, dataver)
+        options.append('-DGEANT4_INSTALL_DATADIR={0}'.format(datapath))
+
+        # Vecgeom
+        if '+vecgeom' in spec:
+            options.append('-DGEANT4_USE_USOLIDS=ON')
+            options.append('-DUSolids_DIR=%s' % spec[
+                'vecgeom'].prefix.lib.CMake.USolids)
+
+        # Visualization options
+        if 'platform=darwin' not in spec:
+            if "+x11" in spec and "+opengl" in spec:
+                options.append('-DGEANT4_USE_OPENGL_X11=ON')
+            if "+motif" in spec and "+opengl" in spec:
+                options.append('-DGEANT4_USE_XM=ON')
+            if "+x11" in spec:
+                options.append('-DGEANT4_USE_RAYTRACER_X11=ON')
+
+        if '+qt' in spec:
+            options.append('-DGEANT4_USE_QT=ON')
+            options.append(
+                '-DQT_QMAKE_EXECUTABLE=%s' %
+                spec['qt'].prefix.bin.qmake)
+
+        # Python
+        if spec.version > Version('10.6.1'):
+            options.append(self.define_from_variant('GEANT4_USE_PYTHON',
+                                                    'python'))
+
+        return options

--- a/repos/fairsoft/packages/geant3/package.py
+++ b/repos/fairsoft/packages/geant3/package.py
@@ -19,6 +19,10 @@ class Geant3(CMakePackage):
     variant('build_type', default='Nightly',
             description='CMake build type',
             values=('Nightly'))
+    variant('cxxstd', default='default',
+            values=('11', '14', '17'),
+            multi=False,
+            description='Force the specified C++ standard when building.')
 
     depends_on('root')
     depends_on('vmc', when='@3:')
@@ -32,6 +36,12 @@ class Geant3(CMakePackage):
 
     def cmake_args(self):
         options = []
+        cxxstd = self.spec.variants['cxxstd'].value
+        if cxxstd == 'default' and self.spec.satisfies('@:2.7'):
+            # geant3 2.7 needs an explicit CXX setting on macOS 11
+            cxxstd = '11'
+        if cxxstd != 'default':
+            options.append(self.define('CMAKE_CXX_STANDARD', cxxstd))
         options.append('-DCMAKE_INSTALL_LIBDIR:PATH=lib')
         options.append('-DROOT_DIR={0}'.format(
                 self.spec['root'].prefix))

--- a/repos/fairsoft/packages/geant4-vmc/package.py
+++ b/repos/fairsoft/packages/geant4-vmc/package.py
@@ -10,8 +10,11 @@ class Geant4Vmc(CMakePackage):
     """Geant4 VMC implements the Virtual Monte Carlo (VMC) for Geant4"""
 
     homepage = "https://github.com/vmc-project/geant4_vmc"
-    url = "https://github.com/vmc-project/geant4_vmc/archive/v3-6.tar.gz"
+    url      = "https://github.com/vmc-project/geant4_vmc/archive/v3-6.tar.gz"
 
+    tags = ['hep']
+
+    version('5-3',    sha256='22f58530963988380509a7741ad6b3dde21806f3862fb55c11cc27f25d3d3c2d')
     version('5-2',    sha256='5bd0e4a4f938048b35724f06075952ecfbc8a97ffc979630cfe2788323845b13')
     version('5-1-p1', sha256='2e3e4705134ea464e993156f71d478cb7d3817f5b6026bf8d9a37d32ec97590b')
     version('5-1',    sha256='ede71f360397dc4d045ec0968acf23b564fa81059c94eb40942b552eea8b5e00')
@@ -28,6 +31,7 @@ class Geant4Vmc(CMakePackage):
     depends_on('geant4')
     depends_on('geant4@10.5:', when='@5-0:')
     depends_on('geant4@10.6:', when='@5-2:')
+    depends_on('geant4@10.7:', when='@5-3:')
     depends_on('vgm')
     depends_on('vmc', when='@5-0:')
 


### PR DESCRIPTION
- [X] (needed) #356  for the legacy version of this PR.

Also a fix for geant3@2.7 on macos11 is included.