### PR TITLE
[legacy] root: flags for GSL and XROOTD

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -304,6 +304,7 @@ if(PACKAGE_SET STREQUAL full)
       "-Dglobus=OFF"
       "-Dgnuinstall=ON"
       "-Dhttp=ON"
+      "-Dmathmore=ON"
       "-Dminuit2=ON"
       "-Dmlp=ON"
       "-Dpyroot=ON"


### PR DESCRIPTION
* See: #364
  PandaRoot needs mathmore
  * Be explicit about mathmore (more for documentation)
    add `-Dmathmore=ON`