### PR TITLE
[spack] Hotfix for concretization on macOS

### DIFF
--- a/repos/fairsoft/packages/fairsoft-bundle/package.py
+++ b/repos/fairsoft/packages/fairsoft-bundle/package.py
@@ -37,7 +37,11 @@ class FairsoftBundle(BundlePackage):
     depends_on('root +spectrum', when='@20.11:')
     depends_on('root ~x~opengl~aqua', when='~graphics')
     depends_on('root +x+opengl', when='+graphics')
-    depends_on('root +aqua', when='+graphics platform=darwin')
+
+    # Using 'platform=' in a when clause gets concretized too late.
+    # and our root recipe disables +aqua on non-macOS now.
+    # depends_on('root +aqua', when='+graphics platform=darwin')
+    depends_on('root +aqua', when='+graphics')
 
     # next (master):
     depends_on('pythia8@8303',          when='@master')

--- a/repos/fairsoft/packages/root/package.py
+++ b/repos/fairsoft/packages/root/package.py
@@ -349,7 +349,10 @@ class Root(CMakePackage):
                 'ON' if self.spec.satisfies('@6.12.02:6.12.99') else 'OFF'),
         ])
 
-        use_asimage = (('+x' in spec) or ('+aqua' in spec))
+        # Only use aqua / cocoa on macOS:
+        use_aqua = self.spec.satisfies('+aqua platform=darwin')
+
+        use_asimage = (('+x' in spec) or use_aqua)
         options += [
             define('asimage', use_asimage),
             define('astiff', use_asimage),
@@ -365,8 +368,7 @@ class Root(CMakePackage):
             '-Dxft:BOOL=%s' % (
                 'ON' if '+x' in spec else 'OFF'),
             '-Dbonjour:BOOL=OFF',
-            '-Dcocoa:BOOL=%s' % (
-                'ON' if '+aqua' in spec else 'OFF'),
+            define('cocoa', use_aqua),
             # -Dcxxmodules=OFF # use clang C++ modules
             '-Ddavix:BOOL=%s' % (
                 'ON' if '+davix' in spec else 'OFF'),


### PR DESCRIPTION
The concretizer handles `platform=` clauses in `when=` statements way too late. It already has finalized things and can't backtrack them at that point.

So let's avoid `platform=` in the concretization step.

Let's handle some of this in the build step.

So what does that mean:
* We concretize root with +aqua, even on Linux.
* Just on non-macOS, we ignore the +aqua in the build step.