### PR TITLE
[legacy] Update Boost download URL

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -96,7 +96,7 @@ unset(packages)
 list(APPEND packages boost)
 set(boost_version "72")
 ExternalProject_Add(boost
-  URL "https://dl.bintray.com/boostorg/release/1.${boost_version}.0/source/boost_1_${boost_version}_0.tar.bz2"
+  URL "https://boostorg.jfrog.io/artifactory/main/release/1.${boost_version}.0/source/boost_1_${boost_version}_0.tar.bz2"
   URL_HASH SHA256=59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722
   BUILD_IN_SOURCE ON
   CONFIGURE_COMMAND "./bootstrap.sh"


### PR DESCRIPTION
Boost moved from bintray to jfrog.
Update download URL.