### PR TITLE
[spack] Updated recipes: boost, cmake, dds, r3broot

### DIFF
--- a/repos/fairsoft-backports/packages/cmake/package.py
+++ b/repos/fairsoft-backports/packages/cmake/package.py
@@ -18,6 +18,7 @@ class Cmake(Package):
 
     executables = ['^cmake$']
 
+    version('3.20.2',   sha256='aecf6ecb975179eb3bb6a4a50cae192d41e92b9372b02300f9e8f1d5f559544e')
     version('3.20.1',   sha256='3f1808b9b00281df06c91dd7a021d7f52f724101000da7985a401678dfe035b0')
     version('3.20.0',   sha256='9c06b2ddf7c337e31d8201f6ebcd3bba86a9a033976a9aee207fe0c6971f4755')
     version('3.19.8',   sha256='09b4fa4837aae55c75fb170f6a6e2b44818deba48335d1969deddfbb34e30369')

--- a/repos/fairsoft/packages/dds/package.py
+++ b/repos/fairsoft/packages/dds/package.py
@@ -49,7 +49,7 @@ class Dds(CMakePackage):
 
     depends_on('boost +shared+log+thread+program_options+filesystem+system+regex+test', when='@2.4:')
     depends_on('boost@1.67:1.72', when='@2.4:3.5.3')
-    depends_on('boost@1.67:1.75', when='@3.5.4:')
+    depends_on('boost@1.67:', when='@3.5.4:')
     depends_on('boost@1.67:1.68 +shared+log+thread+program_options+filesystem+system+regex+test+signals', when='@:2.3')
     conflicts('^boost@1.70:', when='^cmake@:3.14')
 

--- a/repos/fairsoft/packages/r3broot/fairlogger_include.patch
+++ b/repos/fairsoft/packages/r3broot/fairlogger_include.patch
@@ -1,9 +1,9 @@
 --- spack-src/CMakeLists.txt
 +++ spack-src/CMakeLists.txt
 @@ -90,6 +90,9 @@
- 
- find_package2(PUBLIC ROOT  VERSION 6.10.00  REQUIRED)
- find_package2(PUBLIC FairLogger  VERSION 1.2.0 REQUIRED)
+     find_package2(PUBLIC ${dep} REQUIRED VERSION ${FairLogger_${dep}_VERSION})
+   endif()
+ endforeach()
 +get_target_property(fairlogger_include FairLogger::FairLogger INTERFACE_INCLUDE_DIRECTORIES)
 +set(r3broot_deps_includes ${r3broot_deps_includes} ${fairlogger_include})
 +

--- a/repos/fairsoft/packages/r3broot/package.py
+++ b/repos/fairsoft/packages/r3broot/package.py
@@ -16,6 +16,11 @@ class R3broot(CMakePackage):
 
     version('develop', branch='dev')
 
+    variant('cxxstd', default='11',
+            values=('default', '11', '14', '17'),
+            multi=False,
+            description='Force the specified C++ standard when building.')
+
     resource(name='macros', when='@develop',
              git='https://github.com/R3BRootGroup/macros',
              branch='dev')
@@ -23,6 +28,7 @@ class R3broot(CMakePackage):
     depends_on('root +minuit')
     depends_on('fairroot')
 
+    depends_on('faircmakemodules', type='build')
     depends_on('fairlogger')
     depends_on('geant3')
     depends_on('geant4~threads')
@@ -33,8 +39,11 @@ class R3broot(CMakePackage):
     patch('fairlogger_include.patch')
 
     def cmake_args(self):
-        args = ['-DCMAKE_CXX_STANDARD=11']
-        return args
+        options = []
+        cxxstd = self.spec.variants['cxxstd'].value
+        if cxxstd != 'default':
+            options.append('-DCMAKE_CXX_STANDARD={0}'.format(cxxstd))
+        return options
 
     def build(self, spec, prefix):
         super(R3broot, self).build(spec, prefix)


### PR DESCRIPTION
* Boost 1.76.0
* cmake 3.20.2
* Allow DDS to build with any boost version
* R3BRoot
  * Update patches (will look into upstreaming another time)
  * Add dependency on faircmakemodules
  * Add cxxstd variant to be able to compile with C++17