### PR TITLE
[spack] Bump FairCMakeModules, vgm

### DIFF
--- a/repos/fairsoft/packages/faircmakemodules/package.py
+++ b/repos/fairsoft/packages/faircmakemodules/package.py
@@ -14,6 +14,7 @@ class Faircmakemodules(CMakePackage):
     maintainers = ['dennisklein', 'ChristianTackeGSI']
 
     version('master', branch='main')
+    version('0.2.0', sha256='a1f8e1e022eabbc7729ff6055915a3d9c419c4f5ee7301f63df4e04c42be2edd')
     version('0.1.0', sha256='1a2be01d3f3e0d0a5bbaf0ed4a4ea8d2c2f86eeeda3158f760761b41bd568e02')
 
     depends_on('cmake@3.16:')

--- a/repos/fairsoft/packages/fairroot/package.py
+++ b/repos/fairsoft/packages/fairroot/package.py
@@ -31,7 +31,7 @@ class Fairroot(CMakePackage):
 
     depends_on('cmake@3.13.4:', type='build')
     depends_on('boost@1.68.0: +container')
-    depends_on('faircmakemodules', when='@19:')
+    depends_on('faircmakemodules@0.2:', when='@19:')
     depends_on('fairlogger@1.4.0:')
     depends_on('fairmq@1.4.11:')
     depends_on('fairsoft-config', when='@:18,develop')

--- a/repos/fairsoft/packages/fairsoft-bundle/package.py
+++ b/repos/fairsoft/packages/fairsoft-bundle/package.py
@@ -49,7 +49,7 @@ class FairsoftBundle(BundlePackage):
     depends_on('root@6.24.00',          when='@master')
     depends_on('vmc@1-0-p3',            when='@master')
     depends_on('geant3@3.8',            when='@master')
-    depends_on('vgm@4-8',               when='@master')
+    depends_on('vgm@4-9',               when='@master')
     depends_on('geant4-vmc@5-3',        when='@master')
     depends_on('fairsoft-config@develop', when='@master', type='run')
 

--- a/repos/fairsoft/packages/vgm/package.py
+++ b/repos/fairsoft/packages/vgm/package.py
@@ -15,6 +15,7 @@ class Vgm(CMakePackage):
 
     maintainer = ['wdconinc']
 
+    version('4-9', sha256='c420653e1de97e90b9cde87e01e1453fc5934292dbfae6b2fbff66113f761c78')
     version('4-8', sha256='4fcd607b4f100fc00a65fec7a5803575daf9d4919d1808bbd6a30be263c001dd')
     version('4-7', sha256='a5f5588db457dc3e6562d1f7da1707960304560fbb0a261559fa3f112a476aea')
     version('4-6', sha256='6bf0aeef38f357a313e376090b45d3e0713ef9e52ca198075fae8579b8d5a23a')


### PR DESCRIPTION
* FairCMakeModules 0.2.0, spack edition
* Add Version 4-9 for vgm, do not yet bump next release
* - [ ] Check for vgm in next release