### PR TITLE
[spack] dds: Rename WN_PKG_EXECUTABLES to WN_PKG_TARGETS

### DIFF
--- a/repos/fairsoft/packages/dds/fix_wn_bin_2.2.patch
+++ b/repos/fairsoft/packages/dds/fix_wn_bin_2.2.patch
@@ -68,11 +68,11 @@ index 5dfcdee..cb56800 100644
 -
 -set(PREREQ_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 +# top-level executables to package in wn pkg
-+list(APPEND WN_PKG_EXECUTABLES
++list(APPEND WN_PKG_TARGETS
 +  $<TARGET_FILE:dds-agent>
 +  $<TARGET_FILE:dds-user-defaults> )
-+separate_arguments(CLI_WN_PKG_EXECUTABLES
-+  UNIX_COMMAND "${WN_PKG_EXECUTABLES}" )
++separate_arguments(CLI_WN_PKG_TARGETS
++  UNIX_COMMAND "${WN_PKG_TARGETS}" )
 +
 +# Generate a list of what CMake considers to be system prefixes
 +list(APPEND WN_PKG_EXCLUDED_SYSTEM_PREFIXES
@@ -123,7 +123,7 @@ index 5dfcdee..cb56800 100644
 -		-DPREREQ_DIRS=${PREREQ_DIRS} -DDDS_BOOST_LIB_DIR=${DDS_BOOST_LIB_DIR} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
 +	COMMAND ${CMAKE_COMMAND} -E make_directory ${WN_PKG_DIR}
 +  COMMAND ${CMAKE_COMMAND}
-+    -DEXECUTABLES=${CLI_WN_PKG_EXECUTABLES}
++    -DEXECUTABLES=${CLI_WN_PKG_TARGETS}
 +    -DDESTINATION=${WN_PKG_DIR}
 +    -DEXCLUDED_SYSTEM_PREFIXES=${CLI_WN_PKG_EXCLUDED_SYSTEM_PREFIXES}
 +    -P "${CMAKE_SOURCE_DIR}/cmake/DDSCollectWNPkgFiles.cmake"

--- a/repos/fairsoft/packages/dds/fix_wn_bin_2.4.patch
+++ b/repos/fairsoft/packages/dds/fix_wn_bin_2.4.patch
@@ -68,11 +68,11 @@ index a8c297a..adb1f61 100644
 -
 -set(PREREQ_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 +# top-level executables to package in wn pkg
-+list(APPEND WN_PKG_EXECUTABLES
++list(APPEND WN_PKG_TARGETS
 +  $<TARGET_FILE:dds-agent>
 +  $<TARGET_FILE:dds-user-defaults> )
-+separate_arguments(CLI_WN_PKG_EXECUTABLES
-+  UNIX_COMMAND "${WN_PKG_EXECUTABLES}" )
++separate_arguments(CLI_WN_PKG_TARGETS
++  UNIX_COMMAND "${WN_PKG_TARGETS}" )
 +
 +# Generate a list of what CMake considers to be system prefixes
 +list(APPEND WN_PKG_EXCLUDED_SYSTEM_PREFIXES
@@ -123,7 +123,7 @@ index a8c297a..adb1f61 100644
 -		-DPREREQ_DIRS=${PREREQ_DIRS} -DDDS_BOOST_LIB_DIR=${DDS_BOOST_LIB_DIR} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
 +	COMMAND ${CMAKE_COMMAND} -E make_directory ${WN_PKG_DIR}
 +  COMMAND ${CMAKE_COMMAND}
-+    -DEXECUTABLES=${CLI_WN_PKG_EXECUTABLES}
++    -DEXECUTABLES=${CLI_WN_PKG_TARGETS}
 +    -DDESTINATION=${WN_PKG_DIR}
 +    -DEXCLUDED_SYSTEM_PREFIXES=${CLI_WN_PKG_EXCLUDED_SYSTEM_PREFIXES}
 +    -P "${CMAKE_SOURCE_DIR}/cmake/DDSCollectWNPkgFiles.cmake"

--- a/repos/fairsoft/packages/dds/fix_wn_bin_2.5-odc.patch
+++ b/repos/fairsoft/packages/dds/fix_wn_bin_2.5-odc.patch
@@ -116,11 +116,11 @@ index 73d70a4..bb85b06 100644
 -	COMMAND ${CMAKE_COMMAND} -DPREREQ_DESTINATION=${WN_PKG_DIR} -DDDS_AGENT_BIN_PATH=${DDS_AGENT_BIN_PATH}
 -		-DPREREQ_DIRS=${PREREQ_DIRS} -DDDS_BOOST_LIB_DIR=${DDS_BOOST_LIB_DIR} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
 +# top-level executables to package in wn pkg
-+list(APPEND WN_PKG_EXECUTABLES
++list(APPEND WN_PKG_TARGETS
 +  $<TARGET_FILE:dds-agent>
 +  $<TARGET_FILE:dds-user-defaults> )
-+separate_arguments(CLI_WN_PKG_EXECUTABLES
-+  UNIX_COMMAND "${WN_PKG_EXECUTABLES}" )
++separate_arguments(CLI_WN_PKG_TARGETS
++  UNIX_COMMAND "${WN_PKG_TARGETS}" )
 +
 +# Generate a list of what CMake considers to be system prefixes
 +list(APPEND WN_PKG_EXCLUDED_SYSTEM_PREFIXES
@@ -133,7 +133,7 @@ index 73d70a4..bb85b06 100644
 +add_custom_target( wn_bin
 +	COMMAND ${CMAKE_COMMAND} -E make_directory ${WN_PKG_DIR}
 +  COMMAND ${CMAKE_COMMAND}
-+    -DEXECUTABLES=${CLI_WN_PKG_EXECUTABLES}
++    -DEXECUTABLES=${CLI_WN_PKG_TARGETS}
 +    -DDESTINATION=${WN_PKG_DIR}
 +    -DEXCLUDED_SYSTEM_PREFIXES=${CLI_WN_PKG_EXCLUDED_SYSTEM_PREFIXES}
 +    -P "${CMAKE_SOURCE_DIR}/cmake/DDSCollectWNPkgFiles.cmake"

--- a/repos/fairsoft/packages/dds/fix_wn_bin_3.0.patch
+++ b/repos/fairsoft/packages/dds/fix_wn_bin_3.0.patch
@@ -74,11 +74,11 @@ index 78beec7..2afe209 100644
 -set(DDS_AGENT_BIN_PATH $<TARGET_FILE:dds-agent>)
 -set(DDS_PREREQ_SOURCE_BIN_PATH $<TARGET_FILE:dds-commander>)
 +# top-level executables to package in wn pkg
-+list(APPEND WN_PKG_EXECUTABLES
++list(APPEND WN_PKG_TARGETS
 +  $<TARGET_FILE:dds-agent>
 +  $<TARGET_FILE:dds-user-defaults> )
-+separate_arguments(CLI_WN_PKG_EXECUTABLES
-+  UNIX_COMMAND "${WN_PKG_EXECUTABLES}" )
++separate_arguments(CLI_WN_PKG_TARGETS
++  UNIX_COMMAND "${WN_PKG_TARGETS}" )
 +
 +# Generate a list of what CMake considers to be system prefixes
 +list(APPEND WN_PKG_EXCLUDED_SYSTEM_PREFIXES
@@ -131,7 +131,7 @@ index 78beec7..2afe209 100644
 -		-DPREREQ_DIRS=${PREREQ_DIRS} -DDDS_BOOST_LIB_DIR=${DDS_BOOST_LIB_DIR} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
 +	COMMAND ${CMAKE_COMMAND} -E make_directory ${WN_PKG_DIR}
 +  COMMAND ${CMAKE_COMMAND}
-+    -DEXECUTABLES=${CLI_WN_PKG_EXECUTABLES}
++    -DEXECUTABLES=${CLI_WN_PKG_TARGETS}
 +    -DDESTINATION=${WN_PKG_DIR}
 +    -DEXCLUDED_SYSTEM_PREFIXES=${CLI_WN_PKG_EXCLUDED_SYSTEM_PREFIXES}
 +    -P "${CMAKE_SOURCE_DIR}/cmake/DDSCollectWNPkgFiles.cmake"

--- a/repos/fairsoft/packages/dds/fix_wn_bin_3.2_3.5.2.patch
+++ b/repos/fairsoft/packages/dds/fix_wn_bin_3.2_3.5.2.patch
@@ -29,14 +29,14 @@ index ac59845..9e21c78 100644
 -else()
 -  file(TO_CMAKE_PATH "$ENV{LD_LIBRARY_PATH}" ENV_LD_LIBRARY_PATH)
 +# top-level executables to package in wn pkg
-+list(APPEND WN_PKG_EXECUTABLES
++list(APPEND WN_PKG_TARGETS
 +  $<TARGET_FILE:dds-agent>
 +  $<TARGET_FILE:dds-user-defaults> )
 +if(BUILD_TESTS)
-+  list(APPEND $<TARGET_FILE:dds_topology_lib-tests>)
++  list(APPEND WN_PKG_TARGETS $<TARGET_FILE:dds_topology_lib-tests>)
  endif()
-+separate_arguments(CLI_WN_PKG_EXECUTABLES
-+  UNIX_COMMAND "${WN_PKG_EXECUTABLES}" )
++separate_arguments(CLI_WN_PKG_TARGETS
++  UNIX_COMMAND "${WN_PKG_TARGETS}" )
  
 -set(PREREQ_DIRS "$<TARGET_FILE_DIR:dds-user-defaults>::$<TARGET_FILE_DIR:dds_protocol_lib>::$<TARGET_FILE_DIR:dds_intercom_lib>::$<TARGET_FILE_DIR:dds_topology_lib>::$<TARGET_FILE_DIR:dds_ncf>::${DDS_BOOST_LIB_DIR}")
 -foreach(p IN LISTS ENV_LD_LIBRARY_PATH)
@@ -95,7 +95,7 @@ index ac59845..9e21c78 100644
 -	COMMAND ${CMAKE_COMMAND} -DPREREQ_DESTINATION=${WN_PKG_DIR} -DDDS_AGENT_BIN_PATH=${DDS_AGENT_BIN_PATH}
 -		-DPREREQ_DIRS=${PREREQ_DIRS} -DDDS_BOOST_LIB_DIR=${DDS_BOOST_LIB_DIR} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
 +  COMMAND ${CMAKE_COMMAND}
-+    -DEXECUTABLES=${CLI_WN_PKG_EXECUTABLES}
++    -DEXECUTABLES=${CLI_WN_PKG_TARGETS}
 +    -DDESTINATION=${WN_PKG_DIR}
 +    -DEXCLUDED_SYSTEM_PREFIXES=${CLI_WN_PKG_EXCLUDED_SYSTEM_PREFIXES}
 +    -P "${CMAKE_SOURCE_DIR}/cmake/DDSCollectWNPkgFiles.cmake"

--- a/repos/fairsoft/packages/dds/fix_wn_bin_3.5.14.patch
+++ b/repos/fairsoft/packages/dds/fix_wn_bin_3.5.14.patch
@@ -1,4 +1,4 @@
-commit 5a03bce739be8e5f1c8cca38d55c0dd203e230bc
+commit bf91582c16ecce132ab9377727717062af8056a5
 Author: Christian Tacke <58549698+ChristianTackeGSI@users.noreply.github.com>
 Date:   Mon Mar 8 14:55:25 2021 +0100
 
@@ -11,7 +11,7 @@ Date:   Mon Mar 8 14:55:25 2021 +0100
     of the credit for developing this.
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c072db1..f560b85 100644
+index c072db1..1340c72 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -10,7 +10,8 @@ set(DDS_PROTOCOL_VERSION "2")
@@ -41,14 +41,14 @@ index c072db1..f560b85 100644
 -else()
 -  file(TO_CMAKE_PATH "$ENV{LD_LIBRARY_PATH}" ENV_LD_LIBRARY_PATH)
 +# top-level executables to package in wn pkg
-+list(APPEND WN_PKG_EXECUTABLES
++list(APPEND WN_PKG_TARGETS
 +  $<TARGET_FILE:dds-agent>
 +  $<TARGET_FILE:dds-user-defaults> )
 +if(BUILD_TESTS)
-+  list(APPEND $<TARGET_FILE:dds_topology_lib-tests>)
++  list(APPEND WN_PKG_TARGETS $<TARGET_FILE:dds_topology_lib-tests>)
  endif()
-+separate_arguments(CLI_WN_PKG_EXECUTABLES
-+  UNIX_COMMAND "${WN_PKG_EXECUTABLES}" )
++separate_arguments(CLI_WN_PKG_TARGETS
++  UNIX_COMMAND "${WN_PKG_TARGETS}" )
  
 -set(PREREQ_DIRS "$<TARGET_FILE_DIR:dds-user-defaults>::$<TARGET_FILE_DIR:dds_protocol_lib>::$<TARGET_FILE_DIR:dds_intercom_lib>::$<TARGET_FILE_DIR:dds_topology_lib>::$<TARGET_FILE_DIR:dds_ncf>::${DDS_BOOST_LIB_DIR}")
 -foreach(p IN LISTS ENV_LD_LIBRARY_PATH)
@@ -106,7 +106,7 @@ index c072db1..f560b85 100644
 -	COMMAND ${CMAKE_COMMAND} -DPREREQ_DESTINATION=${WN_PKG_DIR} -DDDS_AGENT_BIN_PATH=${DDS_AGENT_BIN_PATH}
 -		-DPREREQ_DIRS=${PREREQ_DIRS} -DDDS_BOOST_LIB_DIR=${DDS_BOOST_LIB_DIR} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
 +  COMMAND ${CMAKE_COMMAND}
-+    -DEXECUTABLES=${CLI_WN_PKG_EXECUTABLES}
++    -DEXECUTABLES=${CLI_WN_PKG_TARGETS}
 +    -DDESTINATION=${WN_PKG_DIR}
 +    -DEXCLUDED_SYSTEM_PREFIXES=${CLI_WN_PKG_EXCLUDED_SYSTEM_PREFIXES}
 +    -P "${CMAKE_SOURCE_DIR}/cmake/DDSCollectWNPkgFiles.cmake"

--- a/repos/fairsoft/packages/dds/fix_wn_bin_3.5.3.patch
+++ b/repos/fairsoft/packages/dds/fix_wn_bin_3.5.3.patch
@@ -29,14 +29,14 @@ index ac59845..9e21c78 100644
 -else()
 -  file(TO_CMAKE_PATH "$ENV{LD_LIBRARY_PATH}" ENV_LD_LIBRARY_PATH)
 +# top-level executables to package in wn pkg
-+list(APPEND WN_PKG_EXECUTABLES
++list(APPEND WN_PKG_TARGETS
 +  $<TARGET_FILE:dds-agent>
 +  $<TARGET_FILE:dds-user-defaults> )
 +if(BUILD_TESTS)
-+  list(APPEND $<TARGET_FILE:dds_topology_lib-tests>)
++  list(APPEND WN_PKG_TARGETS $<TARGET_FILE:dds_topology_lib-tests>)
  endif()
-+separate_arguments(CLI_WN_PKG_EXECUTABLES
-+  UNIX_COMMAND "${WN_PKG_EXECUTABLES}" )
++separate_arguments(CLI_WN_PKG_TARGETS
++  UNIX_COMMAND "${WN_PKG_TARGETS}" )
  
 -set(PREREQ_DIRS "$<TARGET_FILE_DIR:dds-user-defaults>::$<TARGET_FILE_DIR:dds_protocol_lib>::$<TARGET_FILE_DIR:dds_intercom_lib>::$<TARGET_FILE_DIR:dds_topology_lib>::$<TARGET_FILE_DIR:dds_ncf>::${DDS_BOOST_LIB_DIR}")
 -foreach(p IN LISTS ENV_LD_LIBRARY_PATH)
@@ -95,7 +95,7 @@ index ac59845..9e21c78 100644
 -	COMMAND ${CMAKE_COMMAND} -DPREREQ_DESTINATION=${WN_PKG_DIR} -DDDS_AGENT_BIN_PATH=${DDS_AGENT_BIN_PATH}
 -		-DPREREQ_DIRS=${PREREQ_DIRS} -DDDS_BOOST_LIB_DIR=${DDS_BOOST_LIB_DIR} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
 +  COMMAND ${CMAKE_COMMAND}
-+    -DEXECUTABLES=${CLI_WN_PKG_EXECUTABLES}
++    -DEXECUTABLES=${CLI_WN_PKG_TARGETS}
 +    -DDESTINATION=${WN_PKG_DIR}
 +    -DEXCLUDED_SYSTEM_PREFIXES=${CLI_WN_PKG_EXCLUDED_SYSTEM_PREFIXES}
 +    -P "${CMAKE_SOURCE_DIR}/cmake/DDSCollectWNPkgFiles.cmake"

--- a/repos/fairsoft/packages/dds/fix_wn_bin_3.5.4_3.5.10.patch
+++ b/repos/fairsoft/packages/dds/fix_wn_bin_3.5.4_3.5.10.patch
@@ -29,14 +29,14 @@ index 0b1ccff..0f26c15 100644
 -else()
 -  file(TO_CMAKE_PATH "$ENV{LD_LIBRARY_PATH}" ENV_LD_LIBRARY_PATH)
 +# top-level executables to package in wn pkg
-+list(APPEND WN_PKG_EXECUTABLES
++list(APPEND WN_PKG_TARGETS
 +  $<TARGET_FILE:dds-agent>
 +  $<TARGET_FILE:dds-user-defaults> )
 +if(BUILD_TESTS)
-+  list(APPEND $<TARGET_FILE:dds_topology_lib-tests>)
++  list(APPEND WN_PKG_TARGETS $<TARGET_FILE:dds_topology_lib-tests>)
  endif()
-+separate_arguments(CLI_WN_PKG_EXECUTABLES
-+  UNIX_COMMAND "${WN_PKG_EXECUTABLES}" )
++separate_arguments(CLI_WN_PKG_TARGETS
++  UNIX_COMMAND "${WN_PKG_TARGETS}" )
  
 -set(PREREQ_DIRS "$<TARGET_FILE_DIR:dds-user-defaults>::$<TARGET_FILE_DIR:dds_protocol_lib>::$<TARGET_FILE_DIR:dds_intercom_lib>::$<TARGET_FILE_DIR:dds_topology_lib>::$<TARGET_FILE_DIR:dds_ncf>::${DDS_BOOST_LIB_DIR}")
 -foreach(p IN LISTS ENV_LD_LIBRARY_PATH)
@@ -94,7 +94,7 @@ index 0b1ccff..0f26c15 100644
 -	COMMAND ${CMAKE_COMMAND} -DPREREQ_DESTINATION=${WN_PKG_DIR} -DDDS_AGENT_BIN_PATH=${DDS_AGENT_BIN_PATH}
 -		-DPREREQ_DIRS=${PREREQ_DIRS} -DDDS_BOOST_LIB_DIR=${DDS_BOOST_LIB_DIR} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
 +  COMMAND ${CMAKE_COMMAND}
-+    -DEXECUTABLES=${CLI_WN_PKG_EXECUTABLES}
++    -DEXECUTABLES=${CLI_WN_PKG_TARGETS}
 +    -DDESTINATION=${WN_PKG_DIR}
 +    -DEXCLUDED_SYSTEM_PREFIXES=${CLI_WN_PKG_EXCLUDED_SYSTEM_PREFIXES}
 +    -P "${CMAKE_SOURCE_DIR}/cmake/DDSCollectWNPkgFiles.cmake"

--- a/repos/fairsoft/packages/dds/fix_wn_bin_master.patch
+++ b/repos/fairsoft/packages/dds/fix_wn_bin_master.patch
@@ -1,4 +1,4 @@
-commit 5a03bce739be8e5f1c8cca38d55c0dd203e230bc
+commit bf91582c16ecce132ab9377727717062af8056a5
 Author: Christian Tacke <58549698+ChristianTackeGSI@users.noreply.github.com>
 Date:   Mon Mar 8 14:55:25 2021 +0100
 
@@ -11,7 +11,7 @@ Date:   Mon Mar 8 14:55:25 2021 +0100
     of the credit for developing this.
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c072db1..f560b85 100644
+index c072db1..1340c72 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -10,7 +10,8 @@ set(DDS_PROTOCOL_VERSION "2")
@@ -41,14 +41,14 @@ index c072db1..f560b85 100644
 -else()
 -  file(TO_CMAKE_PATH "$ENV{LD_LIBRARY_PATH}" ENV_LD_LIBRARY_PATH)
 +# top-level executables to package in wn pkg
-+list(APPEND WN_PKG_EXECUTABLES
++list(APPEND WN_PKG_TARGETS
 +  $<TARGET_FILE:dds-agent>
 +  $<TARGET_FILE:dds-user-defaults> )
 +if(BUILD_TESTS)
-+  list(APPEND $<TARGET_FILE:dds_topology_lib-tests>)
++  list(APPEND WN_PKG_TARGETS $<TARGET_FILE:dds_topology_lib-tests>)
  endif()
-+separate_arguments(CLI_WN_PKG_EXECUTABLES
-+  UNIX_COMMAND "${WN_PKG_EXECUTABLES}" )
++separate_arguments(CLI_WN_PKG_TARGETS
++  UNIX_COMMAND "${WN_PKG_TARGETS}" )
  
 -set(PREREQ_DIRS "$<TARGET_FILE_DIR:dds-user-defaults>::$<TARGET_FILE_DIR:dds_protocol_lib>::$<TARGET_FILE_DIR:dds_intercom_lib>::$<TARGET_FILE_DIR:dds_topology_lib>::$<TARGET_FILE_DIR:dds_ncf>::${DDS_BOOST_LIB_DIR}")
 -foreach(p IN LISTS ENV_LD_LIBRARY_PATH)
@@ -106,7 +106,7 @@ index c072db1..f560b85 100644
 -	COMMAND ${CMAKE_COMMAND} -DPREREQ_DESTINATION=${WN_PKG_DIR} -DDDS_AGENT_BIN_PATH=${DDS_AGENT_BIN_PATH}
 -		-DPREREQ_DIRS=${PREREQ_DIRS} -DDDS_BOOST_LIB_DIR=${DDS_BOOST_LIB_DIR} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
 +  COMMAND ${CMAKE_COMMAND}
-+    -DEXECUTABLES=${CLI_WN_PKG_EXECUTABLES}
++    -DEXECUTABLES=${CLI_WN_PKG_TARGETS}
 +    -DDESTINATION=${WN_PKG_DIR}
 +    -DEXCLUDED_SYSTEM_PREFIXES=${CLI_WN_PKG_EXCLUDED_SYSTEM_PREFIXES}
 +    -P "${CMAKE_SOURCE_DIR}/cmake/DDSCollectWNPkgFiles.cmake"


### PR DESCRIPTION
WN_PKG_EXECUTABLES isn't really the right name any longer.
It really contains a list of targets. Rename it to
WN_PKG_TARGETS

And fix BUILD_TESTS case.