### PR TITLE
[legacy] Add libreadline-dev to Ubuntu setup

### DIFF
--- a/legacy/setup-ubuntu.sh
+++ b/legacy/setup-ubuntu.sh
@@ -8,7 +8,7 @@ apt-get -y install autoconf automake binutils \
 	curl debianutils file findutils flex g++ gcc gfortran git gzip \
 	hostname libbz2-dev libcurl4-openssl-dev libgsl-dev libicu-dev \
 	libgl1-mesa-dev libglu1-mesa-dev \
-	libncurses-dev libsqlite3-dev libssl-dev libtool \
+	libncurses-dev libreadline-dev libsqlite3-dev libssl-dev libtool \
 	libx11-dev libxerces-c-dev libxext-dev libxft-dev \
 	libxml2-dev libxmu-dev libxpm-dev libyaml-cpp-dev lsb-release make patch python-dev \
 	python3-dev rsync sed subversion tar unzip wget xutils-dev xz-utils


### PR DESCRIPTION
The package seems to be needed for Ubuntu 21.04. Other setups, such as centos7 include it.