### PR TITLE
[legacy] Allow Installing Containers

### DIFF
--- a/test/container/CMakeLists.txt
+++ b/test/container/CMakeLists.txt
@@ -6,6 +6,12 @@
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
+include(GNUInstallDirs)
+
+if(NOT DEFINED FairSoft_CONTAINER_DIR)
+  set(FairSoft_CONTAINER_DIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}")
+endif()
+
 add_subdirectory(legacy)
 
 

--- a/test/container/README.md
+++ b/test/container/README.md
@@ -1,0 +1,14 @@
+## How to build and install legacy containers
+
+```shell
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/cvmfs/fairsoft_dev.gsi.de/try-1 ..
+cmake --build . --target all-legacy-containers
+DESTDIR=/tmp/inst-1 cmake --install . --component container-legacy
+```
+
+Will install to
+`/tmp/inst-1/cvmfs/fairsoft_dev.gsi.de/try-1/share/FairSoft/legacy`.
+
+You can use `-DFairSoft_CONTAINER_DIR` to customize the
+`share/FairSoft` part.

--- a/test/container/legacy/CMakeLists.txt
+++ b/test/container/legacy/CMakeLists.txt
@@ -58,3 +58,12 @@ fs_legacy_container(OS ubuntu VERSION 20.04)
 
 
 add_custom_target(all-legacy-containers DEPENDS ${legacy_containers})
+
+list(TRANSFORM legacy_containers
+     PREPEND "${CMAKE_CURRENT_BINARY_DIR}/"
+     OUTPUT_VARIABLE legacy_containers_for_install)
+
+install(FILES ${legacy_containers_for_install}
+        DESTINATION "${FairSoft_CONTAINER_DIR}/legacy"
+        COMPONENT container-legacy
+        EXCLUDE_FROM_ALL)


### PR DESCRIPTION
We might want to install our containers to some directory.
So use an optional install target (using COMPONENTS) to let CMake install it.