### PR TITLE
[spack] root: +fftw; Add private PandaRoot recipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ if(APPLE)
 endif()
 
 project(FairSoft LANGUAGES C CXX Fortran)
+string(TOLOWER "${PROJECT_NAME}" PROJECT_NAME_LOWER)
 
 if(NOT DEFINED BUILD_METHOD)
   set(BUILD_METHOD legacy)

--- a/legacy/setup-debian.sh
+++ b/legacy/setup-debian.sh
@@ -8,7 +8,7 @@ apt-get -y install autoconf automake binutils \
 	curl debianutils file findutils flex g++ gcc gfortran git gzip \
 	hostname libbz2-dev libcurl4-openssl-dev libgsl-dev libicu-dev \
 	libgl1-mesa-dev libglu1-mesa-dev libgrpc++-dev \
-	libncurses-dev libsqlite3-dev libssl-dev libtool \
+	libncurses-dev libreadline-dev libsqlite3-dev libssl-dev libtool \
 	libx11-dev libxerces-c-dev libxext-dev libxft-dev \
 	libxml2-dev libxmu-dev libxpm-dev libyaml-cpp-dev lsb-release make patch python-dev \
 	python3-dev protobuf-compiler-grpc rsync sed subversion tar unzip wget xutils-dev xz-utils

--- a/legacy/setup-debian.sh
+++ b/legacy/setup-debian.sh
@@ -7,6 +7,7 @@ apt-get -y install autoconf automake binutils \
 	bison build-essential bzip2 ca-certificates coreutils \
 	curl debianutils file findutils flex g++ gcc gfortran git gzip \
 	hostname libbz2-dev libcurl4-openssl-dev libgsl-dev libicu-dev \
+	libfftw3-dev \
 	libgl1-mesa-dev libglu1-mesa-dev libgrpc++-dev \
 	libncurses-dev libreadline-dev libsqlite3-dev libssl-dev libtool \
 	libx11-dev libxerces-c-dev libxext-dev libxft-dev \

--- a/legacy/setup-ubuntu.sh
+++ b/legacy/setup-ubuntu.sh
@@ -7,6 +7,7 @@ apt-get -y install autoconf automake binutils \
 	bison build-essential bzip2 ca-certificates coreutils \
 	curl debianutils file findutils flex g++ gcc gfortran git gzip \
 	hostname libbz2-dev libcurl4-openssl-dev libgsl-dev libicu-dev \
+	libfftw3-dev \
 	libgl1-mesa-dev libglu1-mesa-dev libgrpc++-dev \
 	libncurses-dev libreadline-dev libsqlite3-dev libssl-dev libtool \
 	libx11-dev libxerces-c-dev libxext-dev libxft-dev \

--- a/legacy/setup-ubuntu.sh
+++ b/legacy/setup-ubuntu.sh
@@ -7,10 +7,10 @@ apt-get -y install autoconf automake binutils \
 	bison build-essential bzip2 ca-certificates coreutils \
 	curl debianutils file findutils flex g++ gcc gfortran git gzip \
 	hostname libbz2-dev libcurl4-openssl-dev libgsl-dev libicu-dev \
-	libgl1-mesa-dev libglu1-mesa-dev \
+	libgl1-mesa-dev libglu1-mesa-dev libgrpc++-dev \
 	libncurses-dev libreadline-dev libsqlite3-dev libssl-dev libtool \
 	libx11-dev libxerces-c-dev libxext-dev libxft-dev \
 	libxml2-dev libxmu-dev libxpm-dev libyaml-cpp-dev lsb-release make patch python-dev \
-	python3-dev rsync sed subversion tar unzip wget xutils-dev xz-utils
+	python3-dev protobuf-compiler-grpc rsync sed subversion tar unzip wget xutils-dev xz-utils
 apt-get -y install cmake
 apt-get -y clean

--- a/repos/fairsoft/packages/fairsoft-bundle/package.py
+++ b/repos/fairsoft/packages/fairsoft-bundle/package.py
@@ -37,6 +37,9 @@ class FairsoftBundle(BundlePackage):
     depends_on('root +fortran+pythia6+pythia8+vc~vdt')
     # Mostly for the experiments:
     depends_on('root +python+tmva+mlp+xrootd+sqlite')
+    # FFTW for Panda
+    depends_on('root +fftw')
+    depends_on('fftw~mpi')
     depends_on('root +spectrum', when='@20.11:')
     depends_on('root ~x~opengl~aqua', when='~graphics')
     depends_on('root +x+opengl', when='+graphics')

--- a/repos/fairsoft/packages/pandaroot/package.py
+++ b/repos/fairsoft/packages/pandaroot/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+#   Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright 2019-2021 GSI Helmholtz Centre for Heavy Ion Research GmbH,
+#   Darmstadt, Germany
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class Pandaroot(CMakePackage):
+    """Simulations and Data Analysis for Panda"""
+
+    homepage = "https://git.panda.gsi.de/PandaRootGroup/PandaRoot"
+    git      = "https://git.panda.gsi.de/PandaRootGroup/PandaRoot"
+
+    version('develop', branch='dev')
+
+    depends_on('fairroot')
+    depends_on('root+fftw')
+    depends_on('pythia8')
+    depends_on('hepmc')
+    depends_on('faircmakemodules')
+
+    def setup_build_environment(self, env):
+        env.set("FAIRROOTPATH", self.spec['fairroot'].prefix)
+        env.set("SIMPATH", self.spec["fairroot"].prefix)
+        env.set('SPACK_INCLUDE_DIRS', '', force=True)
+        env.set('SPACK_LINK_DIRS', '', force=True)
+        env.append_path('SPACK_LINK_DIRS', self.spec['root'].prefix.lib)
+        env.append_path('SPACK_LINK_DIRS', self.spec['pythia6'].prefix.lib)
+        env.append_path('SPACK_LINK_DIRS', self.spec['geant4'].prefix.lib)
+
+    def cmake_args(self):
+        options = []
+        options.append('--log-level=VERBOSE')
+        options.append('-DNOVC:BOOL=ON')
+        return options

--- a/test/container/CMakeLists.txt
+++ b/test/container/CMakeLists.txt
@@ -6,6 +6,15 @@
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
+include(GNUInstallDirs)
+
+if(NOT ${PROJECT_NAME}_CONTAINER_DIR)
+  set(${PROJECT_NAME}_CONTAINER_DIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME_LOWER}/container"
+      CACHE PATH "CI Containers (DATADIR/${PROJECT_NAME_LOWER}/container)")
+endif()
+mark_as_advanced(${PROJECT_NAME}_CONTAINER_DIR)
+set(PROJECT_CONTAINER_DIR "${${PROJECT_NAME}_CONTAINER_DIR}")
+
 add_subdirectory(legacy)
 
 
@@ -41,4 +50,15 @@ fs_spack_container(OS ubuntu VERSION 20.04)
 
 
 add_custom_target(all-spack-containers DEPENDS ${spack_containers})
+
+list(TRANSFORM spack_containers
+     PREPEND "${CMAKE_CURRENT_BINARY_DIR}/"
+     OUTPUT_VARIABLE spack_containers_for_install)
+
+install(FILES ${spack_containers_for_install}
+        DESTINATION "${PROJECT_CONTAINER_DIR}"
+        COMPONENT containers
+        EXCLUDE_FROM_ALL)
+
+
 add_custom_target(all-containers DEPENDS all-spack-containers all-legacy-containers)

--- a/test/container/README.md
+++ b/test/container/README.md
@@ -1,0 +1,12 @@
+## How to build and install all containers
+
+```shell
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/cvmfs/fairsoft_dev.gsi.de/ci/for-fairsoft/latest \
+    -DFairSoft_CONTAINER_DIR=container ..
+cmake --build . --target all-containers
+DESTDIR=/tmp/inst-1 cmake --install . --component containers
+```
+
+Will install to
+`/tmp/inst-1/cvmfs/fairsoft_dev.gsi.de/ci/for-fairsoft/latest/container`.

--- a/test/container/legacy/CMakeLists.txt
+++ b/test/container/legacy/CMakeLists.txt
@@ -57,3 +57,12 @@ fs_legacy_container(OS ubuntu VERSION 20.04)
 
 
 add_custom_target(all-legacy-containers DEPENDS ${legacy_containers})
+
+list(TRANSFORM legacy_containers
+     PREPEND "${CMAKE_CURRENT_BINARY_DIR}/"
+     OUTPUT_VARIABLE legacy_containers_for_install)
+
+install(FILES ${legacy_containers_for_install}
+        DESTINATION "${PROJECT_CONTAINER_DIR}"
+        COMPONENT containers
+        EXCLUDE_FROM_ALL)

--- a/test/env/pandaroot/spack.yaml
+++ b/test/env/pandaroot/spack.yaml
@@ -1,0 +1,15 @@
+spack:
+  specs:
+  - hepmc length=CM momentum=GEV
+  - fairsoft-bundle@develop +graphics+mt
+  - fairroot@develop+sim
+  - pandaroot
+  concretization: together
+  view: false
+  packages:
+    all:
+      variants: cxxstd=17
+    mesa:
+      variants: ~llvm
+    mesa18:
+      variants: ~llvm

--- a/test/test-start-container.sh
+++ b/test/test-start-container.sh
@@ -9,10 +9,10 @@ fi
 container="$1"
 ctestcmd="$2"
 
-if [ -z "$FS_INSTALLTREE_BASE" ]
-then
-	FS_INSTALLTREE_BASE=/srv/alfaci/FairSoft/install-tree
-fi
+# Some default paths:
+: ${FS_INSTALLTREE_BASE:="/srv/alfaci/FairSoft/install-tree"}
+: ${SINGULARITY_CONTAINER_ROOT:="/cvmfs/fairsoft_dev.gsi.de/ci/for-fairsoft/latest/container"}
+
 image="${SINGULARITY_CONTAINER_ROOT}/${container}"
 bindmounts="/etc/environment,/cvmfs,$PWD"
 


### PR DESCRIPTION
PandaRoot will need the fftw feature in ROOT. So add it to fairsoft-bundle
See: #445

Also add a private pandaroot recipe and environment for internal testing purposes.

Maybe one day we will add something like this to our CI. So that our CI tests whether any changes to FairSoft break PandaRoot.

The current environment builds PandaRoot/dev against FairRoot/dev and FairSoft/dev.

---

In addition this PR contains the current setup needed to install the CI images on our CD machines.

It also starts to add libfftw3-dev to the debian/ubuntu legacy setups. (the containers on cvmfs already have that).