### PR TITLE
[legacy] Fix dependency tracking for pkgs with `URL` source

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -134,6 +134,7 @@ ExternalProject_Add(boost
   URL "https://boostorg.jfrog.io/artifactory/main/release/1.${boost_version}.0/source/boost_1_${boost_version}_0.tar.bz2"
   URL_HASH SHA256=8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
   BUILD_IN_SOURCE ON
+  BUILD_ALWAYS ON
   CONFIGURE_COMMAND "./bootstrap.sh"
     "--prefix=${CMAKE_INSTALL_PREFIX}"
     ${boost_python_config} ${boost_icu_config}
@@ -151,6 +152,7 @@ set(fmt_version "7.1.3")
 ExternalProject_Add(fmt
   URL "https://github.com/fmtlib/fmt/releases/download/${fmt_version}/fmt-${fmt_version}.zip"
   URL_HASH SHA256=5d98c504d0205f912e22449ecdea776b78ce0bb096927334f80781e720084c9f
+  BUILD_ALWAYS ON
   ${CMAKE_DEFAULT_ARGS} CMAKE_ARGS
     "-DFMT_DOC=OFF"
   ${LOG_TO_FILE}
@@ -240,6 +242,7 @@ if(PACKAGE_SET STREQUAL full)
   ExternalProject_Add(pythia6
     URL https://github.com/alisw/pythia6/archive/${pythia6_version}.tar.gz
     URL_HASH SHA256=b14e82870d3aa33d6fa07f4b1f4d17f1ab80a37d753f91ca6322352b397cb244
+    BUILD_ALWAYS ON
     PATCH_COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/pythia6/add_missing_extern_keyword.patch"
     ${CMAKE_DEFAULT_ARGS} ${LOG_TO_FILE}
     ${DEPENDS_ON_SOURCE_CACHE}
@@ -250,6 +253,7 @@ if(PACKAGE_SET STREQUAL full)
   ExternalProject_Add(hepmc
     URL https://hepmc.web.cern.ch/hepmc/releases/hepmc${hepmc_version}.tgz
     URL_HASH SHA256=86b66ea0278f803cde5774de8bd187dd42c870367f1cbf6cdaec8dc7cf6afc10
+    BUILD_ALWAYS ON
     ${CMAKE_DEFAULT_ARGS} CMAKE_ARGS
       "-Dlength:STRING=CM"
       "-Dmomentum:STRING=GEV"
@@ -262,6 +266,7 @@ if(PACKAGE_SET STREQUAL full)
   ExternalProject_Add(vc
     URL https://github.com/VcDevel/Vc/archive/${vc_version}.tar.gz
     URL_HASH SHA256=50d3f151e40b0718666935aa71d299d6370fafa67411f0a9e249fbce3e6e3952
+    BUILD_ALWAYS ON
     ${CMAKE_DEFAULT_ARGS} ${LOG_TO_FILE}
     ${DEPENDS_ON_SOURCE_CACHE}
   )
@@ -271,6 +276,7 @@ if(PACKAGE_SET STREQUAL full)
   ExternalProject_Add(clhep
     URL http://proj-clhep.web.cern.ch/proj-clhep/dist1/clhep-${clhep_version}.tgz
     URL_HASH SHA256=2517c9b344ad9f55974786ae6e7a0ef8b22f4abcbf506df91194ea2299ce3813
+    BUILD_ALWAYS ON
     ${CMAKE_DEFAULT_ARGS} CMAKE_ARGS
       "-DCLHEP_BUILD_CXXSTD=-std=c++${CMAKE_CXX_STANDARD}"
     ${LOG_TO_FILE}
@@ -290,6 +296,7 @@ if(PACKAGE_SET STREQUAL full)
   ExternalProject_Add(pythia8
     URL https://pythia.org/download/pythia${pythia8_major_version}/pythia${pythia8_version}.tgz
     URL_HASH SHA256=03787c817492bbbf9ef3e9d103b6fb80280ee6d6ff2e87c287a9c433cbaf302c
+    BUILD_ALWAYS ON
     BUILD_IN_SOURCE ON
     CONFIGURE_COMMAND ${CMAKE_BINARY_DIR}/Source/pythia8/configure
       "--with-hepmc2=${CMAKE_INSTALL_PREFIX}"
@@ -313,6 +320,7 @@ if(PACKAGE_SET STREQUAL full)
   ExternalProject_Add(geant4
     URL https://gitlab.cern.ch/geant4/geant4/-/archive/v${geant4_version}/geant4-v${geant4_version}.tar.gz
     URL_HASH SHA256=04d11d4d9041507e7f86f48eb45c36430f2b6544a74c0ccaff632ac51d9644f1
+    BUILD_ALWAYS ON
     ${CMAKE_DEFAULT_ARGS} CMAKE_ARGS
       "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
       ${mt}
@@ -348,6 +356,7 @@ if(PACKAGE_SET STREQUAL full)
   ExternalProject_Add(root
     URL https://root.cern/download/root_v${root_version}.source.tar.gz
     URL_HASH SHA256=907f69f4baca1e4f30eeb4979598ca7599b6aa803ca046e80e25b6bbaa0ef522
+    BUILD_ALWAYS ON
     ${CMAKE_DEFAULT_ARGS} CMAKE_ARGS
       "-Daqua=ON"
       "-Dasimage=ON"


### PR DESCRIPTION
fix #460