### PR TITLE
Fix compiler error on macosx

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -201,6 +201,7 @@ ExternalProject_Add(zeromq
     "-DWITH_PERF_TOOL=ON"
     "-DZMQ_BUILD_TESTS=ON"
     "-DENABLE_CPACK=OFF"
+  PATCH_COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/zeromq/fix_gnutls_macosx_v4.3.4.patch"
   ${LOG_TO_FILE}
   ${DEPENDS_ON_SOURCE_CACHE}
 )

--- a/legacy/zeromq/fix_gnutls_macosx_v4.3.4.patch
+++ b/legacy/zeromq/fix_gnutls_macosx_v4.3.4.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dd3d8eb9..d887d006 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1351,6 +1351,11 @@ else()
+     target_include_directories(
+       objects PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
++    if(GNUTLS_FOUND)
++      target_include_directories(objects PRIVATE ${GNUTLS_INCLUDE_DIR})
++    endif()
++
++
+   endif()
+ 
+   if(BUILD_SHARED)


### PR DESCRIPTION
At least on macosx 10.5 with only the command line tools installed the zeromq
compilation crashes because the gnutls headers are not found. Those headers
are on this system not installed in a system path but properly found by CMake.
Unfortunately the include directory wasn't added when compiling the sources.