### PR TITLE
[legacy] onnxruntime: Fix CMake config files

### DIFF
--- a/legacy/onnxruntime/install_config_files.patch
+++ b/legacy/onnxruntime/install_config_files.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 000000000..28a7dcb58
 --- /dev/null
 +++ b/cmake/ONNXRuntimeConfig.cmake
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,45 @@
 +# Custom cmake config file by fuhlig to enable find_package(ONNXRuntime)
 +# Inspired by https://stackoverflow.com/a/66494534
 +#
@@ -40,6 +40,14 @@ index 000000000..28a7dcb58
 +set_target_properties(ONNXRuntime::ONNXRuntime PROPERTIES
 +  IMPORTED_LOCATION "${ONNXRuntime_LIBRARY}"
 +  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCDIRS}"
++  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCDIRS}/onnxruntime/core/common"
++  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCDIRS}/onnxruntime/core/common/logging"
++  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCDIRS}/onnxruntime/core/framework"
++  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCDIRS}/onnxruntime/core/graph"
++  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCDIRS}/onnxruntime/core/optimizer"
++  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCDIRS}/onnxruntime/core/providers"
++  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCDIRS}/onnxruntime/core/providers/cpu"
++  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCDIRS}/onnxruntime/core/session"
 +)
 diff --git a/cmake/ONNXRuntimeConfigVersion.cmake b/cmake/ONNXRuntimeConfigVersion.cmake
 new file mode 100644


### PR DESCRIPTION
The layout of the include directories between a onnxruntime installation from the binary package and the package build from sources is different. The headers from the binary package are installed in one flat directory structure, the headers from the source installation are put into a directory structure. Add all the directories to the list of include directories of the CMake target such that the user code does not need to provide any directory information but only the header file names.