### PR TITLE
[legacy] onnxruntime: Fix compilation error

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -430,6 +430,7 @@ list(APPEND packages onnxruntime)
 set(onnxruntime_version "1.12.1")
 ExternalProject_Add(onnxruntime
   PATCH_COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/onnxruntime/install_config_files.patch"
+  COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/onnxruntime/fix_python_detection.patch"
   GIT_REPOSITORY https://github.com/microsoft/onnxruntime/ GIT_TAG v${onnxruntime_version}
   GIT_SHALLOW ON
   GIT_SUBMODULES

--- a/legacy/onnxruntime/fix_python_detection.patch
+++ b/legacy/onnxruntime/fix_python_detection.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f914e78b..39e22923 100644
+--- a/cmake/external/onnx/CMakeLists.txt
++++ b/cmake/external/onnx/CMakeLists.txt
+@@ -113,9 +113,9 @@ endif()
+ 
+ # find_package Python has replaced PythonInterp and PythonLibs since cmake 3.12
+ # Use the following command in the future; now this is only compatible with the latest pybind11
+-# find_package(Python ${PY_VERSION} COMPONENTS Interpreter Development REQUIRED)
+-find_package(PythonInterp ${PY_VERSION} REQUIRED)
+-find_package(PythonLibs ${PY_VERSION})
++ find_package(Python ${PY_VERSION} COMPONENTS Interpreter Development REQUIRED)
++#find_package(PythonInterp ${PY_VERSION} REQUIRED)
++#find_package(PythonLibs ${PY_VERSION})
+ 
+ if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
+   set(CMAKE_NO_SYSTEM_FROM_IMPORTED 1)
+@@ -256,7 +256,7 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
+     endif()
+ 
+     add_custom_command(OUTPUT "${GENERATED_PROTO}"
+-                       COMMAND "${PYTHON_EXECUTABLE}" "${GEN_PROTO_PY}"
++                       COMMAND "${Python_EXECUTABLE}" "${GEN_PROTO_PY}"
+                                ARGS ${GEN_PROTO_ARGS}
+                        DEPENDS ${INFILE}
+                        COMMENT "Running gen_proto.py on ${INFILE}"


### PR DESCRIPTION
In case a mixed Python2 and Python3 installation is on the system the needed files for protobuffer can't be created and the compilation stops with an error. The patch fixes the problem by properly finding and using the correct Python installation.
Fixes #485 .