### PR TITLE
[legacy] patches for compiling dds, clhep and pythia8 with c++20.

### DIFF
--- a/legacy/clhep/clhep_cxx20.patch
+++ b/legacy/clhep/clhep_cxx20.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/Modules/ClhepVariables.cmake b/cmake/Modules/ClhepVariables.cmake
+index ae48462..1f85cc0 100644
+--- a/cmake/Modules/ClhepVariables.cmake
++++ b/cmake/Modules/ClhepVariables.cmake
+@@ -263,7 +263,7 @@ macro( _clhep_check_cxxstd )
+   elseif( "${CLHEP_BUILD_CXXSTD}" STREQUAL "-std=c++17" )
+     _clhep_verify_cxx17()
+   elseif( DEFINED CLHEP_BUILD_CXXSTD )
+-    message( FATAL_ERROR "${CLHEP_BUILD_CXXSTD} is not supported.  Supported extensions are c++11, c++1y, and c++14.")
++    message( WARNING "${CLHEP_BUILD_CXXSTD} is not officially supported.  Supported extensions are c++11, c++1y, and c++14.")
+   else()
+     # presume -std=c++11
+     set(CLHEP_BUILD_CXXSTD "-std=c++11")

--- a/legacy/dds/dds_c++20.patch
+++ b/legacy/dds/dds_c++20.patch
@@ -1,0 +1,96 @@
+diff --git a/dds-protocol-lib/src/BaseChannelImpl.h b/dds-protocol-lib/src/BaseChannelImpl.h
+index f2b150f..26fb177 100644
+--- a/dds-protocol-lib/src/BaseChannelImpl.h
++++ b/dds-protocol-lib/src/BaseChannelImpl.h
+@@ -237,7 +237,7 @@ namespace dds
+             DDS_DECLARE_EVENT_HANDLER_CLASS(CChannelMessageHandlersImpl)
+ 
+           protected:
+-            CBaseChannelImpl<T>(boost::asio::io_context& _service, uint64_t _protocolHeaderID)
++            CBaseChannelImpl(boost::asio::io_context& _service, uint64_t _protocolHeaderID)
+                 : CChannelEventHandlersImpl()
+                 , CChannelMessageHandlersImpl()
+                 , m_isHandshakeOK(false)
+@@ -265,7 +265,7 @@ namespace dds
+             }
+ 
+           public:
+-            ~CBaseChannelImpl<T>()
++            ~CBaseChannelImpl()
+             {
+                 LOG(dds::misc::info) << "Channel " << gChannelTypeName[m_channelType] << " destructor is called";
+                 stop();
+diff --git a/dds-protocol-lib/src/BaseSMChannelImpl.h b/dds-protocol-lib/src/BaseSMChannelImpl.h
+index da4960f..7606536 100644
+--- a/dds-protocol-lib/src/BaseSMChannelImpl.h
++++ b/dds-protocol-lib/src/BaseSMChannelImpl.h
+@@ -194,7 +194,7 @@ namespace dds
+             DDS_DECLARE_EVENT_HANDLER_CLASS(CChannelMessageHandlersImpl)
+ 
+           protected:
+-            CBaseSMChannelImpl<T>(boost::asio::io_context& _service,
++            CBaseSMChannelImpl(boost::asio::io_context& _service,
+                                   const std::string& _inputName,
+                                   const std::string& _outputName,
+                                   uint64_t _protocolHeaderID,
+@@ -209,7 +209,7 @@ namespace dds
+                 defaultInit({ _inputName }, _outputName, _inputOpenType, _outputOpenType);
+             }
+ 
+-            CBaseSMChannelImpl<T>(boost::asio::io_context& _service,
++            CBaseSMChannelImpl(boost::asio::io_context& _service,
+                                   const std::vector<std::string>& _inputNames,
+                                   const std::string& _outputName,
+                                   uint64_t _protocolHeaderID,
+@@ -250,7 +250,7 @@ namespace dds
+             }
+ 
+           public:
+-            ~CBaseSMChannelImpl<T>()
++            ~CBaseSMChannelImpl()
+             {
+                 LOG(dds::misc::info) << "SM: channel destructor is called. MQ: " << getName();
+                 stop();
+diff --git a/dds-protocol-lib/src/ClientChannelImpl.h b/dds-protocol-lib/src/ClientChannelImpl.h
+index 71a0f60..90dd7dc 100644
+--- a/dds-protocol-lib/src/ClientChannelImpl.h
++++ b/dds-protocol-lib/src/ClientChannelImpl.h
+@@ -23,7 +23,7 @@ namespace dds
+             typedef std::function<void(T*)> handlerEventFunction_t;
+ 
+           protected:
+-            CClientChannelImpl<T>(boost::asio::io_context& _service,
++            CClientChannelImpl(boost::asio::io_context& _service,
+                                   EChannelType _channelType,
+                                   uint64_t _protocolHeaderID)
+                 : CBaseChannelImpl<T>(_service, _protocolHeaderID)
+@@ -63,7 +63,7 @@ namespace dds
+                     });
+             }
+ 
+-            ~CClientChannelImpl<T>()
++            ~CClientChannelImpl()
+             {
+             }
+ 
+diff --git a/dds-protocol-lib/src/ServerChannelImpl.h b/dds-protocol-lib/src/ServerChannelImpl.h
+index 539b825..1bc89be 100644
+--- a/dds-protocol-lib/src/ServerChannelImpl.h
++++ b/dds-protocol-lib/src/ServerChannelImpl.h
+@@ -18,7 +18,7 @@ namespace dds
+         class CServerChannelImpl : public CBaseChannelImpl<T>
+         {
+           protected:
+-            CServerChannelImpl<T>(boost::asio::io_context& _service, const channelTypeVector_t _requiredChannelTypes)
++            CServerChannelImpl(boost::asio::io_context& _service, const channelTypeVector_t _requiredChannelTypes)
+                 : CBaseChannelImpl<T>(_service, 0)
+                 , m_requiredChannelTypes(_requiredChannelTypes)
+             {
+@@ -81,5 +81,5 @@ namespace dds
+                 //                    });
+             }
+ 
+-            ~CServerChannelImpl<T>()
++            ~CServerChannelImpl()
+             {
+             }

--- a/legacy/pythia8/pythia8_cxx20.patch
+++ b/legacy/pythia8/pythia8_cxx20.patch
@@ -1,0 +1,31 @@
+diff --git a/include/Pythia8/SusyLesHouches.h b/include/Pythia8/SusyLesHouches.h
+index 2f1d9fd..5090c00 100644
+--- a/include/Pythia8/SusyLesHouches.h
++++ b/include/Pythia8/SusyLesHouches.h
+@@ -28,7 +28,7 @@ namespace Pythia8 {
+   public:
+ 
+     //Constructor.
+-    LHblock<T>() : idnow(0), qDRbar(), i(), val() {} ;
++    LHblock() : idnow(0), qDRbar(), i(), val() {} ;
+ 
+     //Does block exist?
+     bool exists() { return int(entry.size()) == 0 ? false : true ; };
+@@ -129,7 +129,7 @@ namespace Pythia8 {
+   template <int size> class LHmatrixBlock {
+   public:
+     //Constructor. Set uninitialized and explicitly zero.
+-    LHmatrixBlock<size>() : entry(), qDRbar(), val() {
++    LHmatrixBlock() : entry(), qDRbar(), val() {
+       initialized=false;
+       for (i=1;i<=size;i++) {
+         for (j=1;j<=size;j++) {
+@@ -208,7 +208,7 @@ namespace Pythia8 {
+   template <int size> class LHtensor3Block {
+   public:
+     //Constructor. Set uninitialized and explicitly zero.
+-    LHtensor3Block<size>() : entry(), qDRbar(), val() {
++    LHtensor3Block() : entry(), qDRbar(), val() {
+       initialized=false;
+       for (i=1;i<=size;i++) {
+         for (j=1;j<=size;j++) {


### PR DESCRIPTION
These are not yet applied in legacy.cmake.

When trying to compile FairSoft with C++20, I had to change a few things:
* clhep manually checks for version strings and refuses c++20 in cmake. If that check it bypassed, it compiles. 
* dds and pythia8 sometimes put template brackets in the names of constructors and destructors, which C++20 [forbids](https://eel.is/c++draft/diff.cpp17#class). 

Both of these were easy enough to fix. Then I tried to compile root with c++20, which went poorly. TL;DR: cling does not include several C++20 constructs like ``std::construct_at``, which libstdc++ headers assume to be available if ``__cplusplus > 201703``. I tried making cling set __cplusplus to 201703, but that failed for some other reason, so for now I will just keep ROOT on C++17 and try to run everything else with C++20 and hope that for the best (e.g. no repetition of _GLIBCXX_USE_CXX11_ABI).

Anyhow, I am sure that C++20 support will arrive in root Really Soon Now and then these patches might be helpful to fully support C++20. 