### PR TITLE
[legacy] root: Enable pythia6

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -349,6 +349,7 @@ ExternalProject_Add(root
     "-Dminuit2=ON"
     "-Dmlp=ON"
     "-Dpyroot=ON"
+    "-Dpythia6=ON"
     "-Dreflex=OFF"
     "-Droofit=ON"
     "-Drpath=ON"

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -497,7 +497,7 @@ add_custom_target(source-cache
 
 include(CTest)
 
-foreach(ver IN ITEMS 18.4 18.6 18.8)
+foreach(ver IN ITEMS 18.6 18.8)
   set(TEST_VERSION v${ver}_patches)
   configure_file(test/legacy/fairroot.sh.in ${CMAKE_BINARY_DIR}/test_fairroot_${ver}.sh @ONLY)
   add_test(NAME FairRoot_${ver}


### PR DESCRIPTION
ROOT 6.30/00 deprecated and disabled it by default
* https://github.com/root-project/root/commit/1c74d59d08d7547f298d04eafd4cd7033aad52a7
* https://github.com/root-project/root/commit/ebe6694fb90a696999e927bc14080e7649631903

Resolves #514