### PR TITLE
[legacy] Fix missing R(UN)PATH for Boost libraries

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -115,6 +115,16 @@ set(boost_features
   "visibility=hidden"
   "pch=off"
 )
+
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+
+if("${isSystemDir}" STREQUAL "-1")
+  list(APPEND boost_features
+    "hardcode-dll-paths=true"
+    "dll-path=${CMAKE_INSTALL_PREFIX}/lib"
+  )
+endif()
+
 ExternalProject_Add(boost
   URL "https://boostorg.jfrog.io/artifactory/main/release/1.${boost_version}.0/source/boost_1_${boost_version}_0.tar.bz2"
   URL_HASH SHA256=6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e


### PR DESCRIPTION
Should fix #494.

From:
https://www.bfgroup.xyz/b2/manual/release/index.html#bbv2.builtin.features.hardcode-dll-paths
https://www.bfgroup.xyz/b2/manual/release/index.html#bbv2.builtin.features.dll-path
https://www.bfgroup.xyz/b2/manual/release/index.html#bbv2.faq.dll-path

With this I get:
```
 ldd install/lib/libboost_log.so
	linux-vdso.so.1 (0x00007ffebc525000)
	libboost_filesystem.so.1.83.0 => /home/user/dev/FairSoft/install/lib/libboost_filesystem.so.1.83.0 (0x00007f9dc302f000)
	libboost_thread.so.1.83.0 => /home/user/dev/FairSoft/install/lib/libboost_thread.so.1.83.0 (0x00007f9dc300b000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f9dc2c00000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f9dc2fcf000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f9dc2800000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f9dc313a000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f9dc2ee2000)

 objdump -x install/lib/libboost_log.so | grep PATH
  RUNPATH              /home/user/dev/FairSoft/install/lib
```

No RPATH, but RUNPATH.
Tested on Linux. Will test on MacOS in a lil bit