### PR TITLE
[legacy] Add new package dependencies where missing

### DIFF
--- a/legacy/setup-archlinux.sh
+++ b/legacy/setup-archlinux.sh
@@ -10,5 +10,5 @@ pacman -S --noconfirm \
     lsb-release lz4 m4 make mesa ncurses net-tools openblas openssl patch \
     pkg-config procps python python-numpy python-pygments python-pyyaml \
     readline rsync sed sqlite subversion tar tbb unzip util-linux-libs wget \
-    which xerces-c xz yaml-cpp
+    which xerces-c xz yaml-cpp zstd
 pacman -Scc --noconfirm

--- a/legacy/setup-debian.sh
+++ b/legacy/setup-debian.sh
@@ -9,9 +9,9 @@ apt-get -y install autoconf automake binutils \
 	hostname libbz2-dev libcurl4-openssl-dev libgsl-dev libicu-dev \
 	libfftw3-dev \
 	libgl1-mesa-dev libglu1-mesa-dev libgrpc++-dev \
-	libncurses-dev libreadline-dev libsqlite3-dev libssl-dev libtool \
+	liblzma-dev libncurses-dev libreadline-dev libsqlite3-dev libssl-dev libtool \
 	libx11-dev libxerces-c-dev libxext-dev libxft-dev \
-	libxml2-dev libxmu-dev libxpm-dev libyaml-cpp-dev lsb-release make patch \
+	libxml2-dev libxmu-dev libxpm-dev libyaml-cpp-dev libzstd-dev lsb-release make patch \
 	python3-dev protobuf-compiler-grpc rsync sed subversion tar unzip wget xutils-dev xz-utils
 apt-get -y -t buster-backports install cmake || \
 	apt-get -y install cmake

--- a/legacy/setup-fedora.sh
+++ b/legacy/setup-fedora.sh
@@ -9,7 +9,7 @@ dnf -y install \
     grpc-plugins gsl-devel gzip help2man hostname hwloc-devel libX11-devel libXau-devel \
     libXdmcp-devel libXext-devel libXfont-devel libXft-devel libXmu-devel libXpm-devel \
     libXrender-devel libbsd-devel libicu-devel libjpeg-turbo-devel libtiff-devel libtool \
-    libunistring-devel libuuid-devel libxml2-devel lz4-devel m4 make make mesa-libGL-devel \
+    libunistring-devel libuuid-devel libxml2-devel libzstd-devel lz4-devel m4 make make mesa-libGL-devel \
     mesa-libGLU-devel ncurses-devel openblas-devel openssl-devel patch procps python \
     python-devel python3-numpy python3-pygments python3-pyyaml readline-devel redhat-lsb-core \
     rsync sed sqlite-devel subversion tar tbb-devel unzip wget which xerces-c-devel xz-devel \

--- a/legacy/setup-opensuse.sh
+++ b/legacy/setup-opensuse.sh
@@ -8,7 +8,7 @@ fftw-devel findutils flex gcc-c++ gcc-fortran gdbm-devel gettext-devel git gperf
 gzip help2man hostname hwloc hwloc-devel m4 make libbsd-devel libtool libicu-devel \
 glu-devel grpc-devel libunistring-devel libuuid-devel libX11-devel libXau-devel \
 libXdmcp-devel libXext-devel libXfont-devel libXft-devel libxml2-devel \
-libXmu-devel libXpm-devel libXrender-devel liblz4-devel lsb-release Mesa-devel \
+libXmu-devel libXpm-devel libXrender-devel liblz4-devel libzstd-devel lsb-release Mesa-devel \
 ncurses-devel openssl-devel patch procps python python-devel python3-devel \
 readline-devel rsync sed subversion tar libtbb2 tbb-devel unzip wget which \
 libxerces-c-devel xz xz-devel yaml-cpp-devel

--- a/legacy/setup-ubuntu.sh
+++ b/legacy/setup-ubuntu.sh
@@ -9,9 +9,9 @@ apt-get -y install autoconf automake binutils \
 	hostname libbz2-dev libcurl4-openssl-dev libgsl-dev libicu-dev \
 	libfftw3-dev \
 	libgl1-mesa-dev libglu1-mesa-dev libgrpc++-dev \
-	libncurses-dev libreadline-dev libsqlite3-dev libssl-dev libtool \
+	liblzma-dev libncurses-dev libreadline-dev libsqlite3-dev libssl-dev libtool \
 	libx11-dev libxerces-c-dev libxext-dev libxft-dev \
-	libxml2-dev libxmu-dev libxpm-dev libyaml-cpp-dev lsb-release make patch \
+	libxml2-dev libxmu-dev libxpm-dev libyaml-cpp-dev libzstd-dev lsb-release make patch \
 	python3-dev protobuf-compiler-grpc rsync sed subversion tar unzip wget xutils-dev xz-utils
 apt-get -y install cmake
 apt-get -y clean


### PR DESCRIPTION
Add libzst, liblzma and corresponing developer packages in all setup scripts where they were not yet used. 
These two libs are needed to enable boost streaming with compression.