### PR TITLE
[legacy] test: Make sure build & install dirs exist for fairroot.sh.in

### DIFF
--- a/test/legacy/fairroot.sh.in
+++ b/test/legacy/fairroot.sh.in
@@ -8,7 +8,8 @@ version="@TEST_VERSION@"
 sourcedir=FairRoot_${version}
 git clone -b ${version} https://github.com/FairRootGroup/FairRoot $sourcedir
 pushd $sourcedir
-export FAIRROOTPATH="$(realpath ./install)"
+mkdir -p build/install
+export FAIRROOTPATH="$(realpath ./build/install)"
 cmake -S. -Bbuild \
   -DCMAKE_INSTALL_PREFIX=$FAIRROOTPATH
 cmake --build build --target install -j @NCPUS@


### PR DESCRIPTION
realpath fails here:
https://cdash.gsi.de/testDetails.php?test=18766745&build=436639
since the dir(s) don't exist (yet).