### PR TITLE
[legacy] boost: find needed libs on macosx

### DIFF
--- a/FairSoftConfig.cmake
+++ b/FairSoftConfig.cmake
@@ -79,3 +79,16 @@ if(APPLE)
   string(STRIP "${macos_sdk_path}" macos_sdk_path)
   set(CMAKE_OSX_SYSROOT "${macos_sdk_path}" CACHE FILEPATH "macOS SDK" FORCE)
 endif()
+
+#
+# LZMA and ZSTD
+#
+# On macOS both packages aren't installed in some standard system path
+# so we need to give CMake some hints where to find them.
+# On Linux the packages are in the default system paths and are found
+# automatically.
+if(APPLE)
+  execute_process(COMMAND brew --prefix OUTPUT_VARIABLE brew_prefix)
+  set(LibLZMA_ROOT ${brew_prefix})
+  set(ZSTD_ROOT ${brew_prefix})
+endif()

--- a/cmake/FindZSTD.cmake
+++ b/cmake/FindZSTD.cmake
@@ -1,0 +1,60 @@
+################################################################################
+# Copyright (C) 2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH       #
+#                                                                              #
+#              This software is distributed under the terms of the             #
+#              GNU Lesser General Public Licence (LGPL) version 3,             #
+#                  copied verbatim in the file "LICENSE"                       #
+################################################################################
+#[=======================================================================[
+FindZSTD
+-----------
+
+Find ZSTD compression algorithm headers and library.
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project:
+
+``ZSTD_FOUND``
+  True if libzstd headers and library were found.
+``ZSTD_INCLUDE_DIR``
+  Directory where libzstd headers are located.
+``ZSTD_LIBRARY``
+  Zstd library to link against.
+``ZSTD_BINARY``
+  Zstd binary
+``ZSTD_VERSION``
+    the version of ZSTD found.
+#]=======================================================================]
+
+find_path(ZSTD_INCLUDE_DIR zstd.h)
+
+if(NOT ZSTD_LIBRARY)
+  find_library(ZSTD_LIBRARY NAMES zstd lzstd libzstd NAMES_PER_DIR PATH_SUFFIXES lib)
+endif()
+
+if(NOT ZSTD_BINARY)
+  find_program(ZSTD_BINARY NAMES zstd NAMES_PER_DIR PATH_SUFFIXES bin)
+endif()
+
+if(ZSTD_BINARY)
+  execute_process(COMMAND ${ZSTD_BINARY} --version
+                    OUTPUT_VARIABLE zstd_version
+                   )
+  string(REGEX REPLACE "^.*([0-9]\\.[0-9]\\.[0-9])+.*" "\\1" zstd_version1 "${zstd_version}")
+  set(ZSTD_VERSION "${zstd_version1}" CACHE STRING "ZSTD version info for Boost" FORCE)
+elseif(ZSTD_INCLUDE_DIR)
+  file(READ ${ZSTD_INCLUDE_DIR}/zstd.h ZSTD_VERSION_INFO)
+  string(REGEX REPLACE ".*#define[ ]+ZSTD_VERSION_MAJOR[ ]+([0-9]+).*" "\\1" ZSTD_VERSION_MAJOR "${ZSTD_VERSION_INFO}")
+  string(REGEX REPLACE ".*#define[ ]+ZSTD_VERSION_MINOR[ ]+([0-9]+).*" "\\1" ZSTD_VERSION_MINOR "${ZSTD_VERSION_INFO}")
+  string(REGEX REPLACE ".*#define[ ]+ZSTD_VERSION_RELEASE[ ]+([0-9]+).*" "\\1" ZSTD_VERSION_RELEASE "${ZSTD_VERSION_INFO}")
+  set(ZSTD_VERSION "${ZSTD_VERSION_MAJOR}.${ZSTD_VERSION_MINOR}.${ZSTD_VERSION_RELEASE}" CACHE STRING "ZSTD version info for Boost" FORCE)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ZSTD  REQUIRED_VARS  ZSTD_LIBRARY
+                                                       ZSTD_INCLUDE_DIR
+                                        VERSION_VAR    ZSTD_VERSION
+                                 )
+mark_as_advanced( ZSTD_INCLUDE_DIR ZSTD_LIBRARY )

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -1,11 +1,48 @@
 ################################################################################
-# Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2020-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 cmake_minimum_required(VERSION 3.19...3.28 FATAL_ERROR)
+cmake_policy(VERSION 3.19...3.28)
+
+find_package(LibLZMA)
+if(LibLZMA_FOUND)
+  message(STATUS "LZMA installation found. Boost iostream will be build with lzma compression")
+else()
+  message(WARNING "LZMA installation not found. Boost iostream will be build without lzma compression")
+endif()
+
+find_package(ZSTD)
+if(ZSTD_FOUND)
+  message(STATUS "ZSTD installation found. Boost iostream will be build with zstd compression")
+else()
+  message(WARNING "ZSTD installation not found. Boost iostream will be build without zstd compression")
+endif()
+
+if(APPLE AND LibLZMA_FOUND)
+  set(LZMA_EXTERNAL "using lzma   :" CACHE STRING "LZMA exetrnal usage for Boost" FORCE)
+  set(LZMA_VERSION "${LIBLZMA_VERSION}" CACHE STRING "LZMA version info for Boost" FORCE)
+  set(LZMA_STRING ": <include>${LIBLZMA_INCLUDE_DIR}  <search>${LIBLZMA_LIBRARY} ;" CACHE STRING "LZMA install info for Boost" FORCE)
+else()
+  set(LZMA_EXTERNAL "" CACHE STRING "LZMA exetrnal usage for Boost" FORCE)
+  set(LZMA_VERSION "" CACHE STRING "LZMA version info for Boost" FORCE)
+  set(LZMA_STRING "" CACHE STRING "LZMA install info for Boost" FORCE)
+endif()
+
+if(APPLE AND ZSTD_FOUND)
+  get_filename_component(ZSTD_LIBRARY_DIR ${ZSTD_LIBRARY} DIRECTORY)
+  set(ZSTD_EXTERNAL "using zstd   :" CACHE STRING "ZSTD exetrnal usage for Boost" FORCE)
+  set(ZSTD_VERSION "${ZSTD_VERSION}" CACHE STRING "ZSTD version info for Boost" FORCE)
+  set(ZSTD_STRING ": <include>${ZSTD_INCLUDE_DIR} <search>${ZSTD_LIBRARY_DIR} ;" CACHE STRING "ZSTD install info for Boost" FORCE)
+else()
+  set(ZSTD_EXTERNAL "" CACHE STRING "ZSTD exetrnal usage for Boost" FORCE)
+  set(ZSTD_VERSION "" CACHE STRING "ZSTD version info for Boost" FORCE)
+  set(ZSTD_STRING "" CACHE STRING "ZSTD install info for Boost" FORCE)
+endif()
+
 
 find_package(Git REQUIRED)
 find_package(Patch REQUIRED)

--- a/legacy/boost/site-config.jam.in
+++ b/legacy/boost/site-config.jam.in
@@ -2,3 +2,9 @@ using python : @Python_VERSION_MAJOR@.@Python_VERSION_MINOR@
              : @Python_EXECUTABLE_NAME@
              : @Python_INCLUDE_DIRS@
              : @Python_LIBRARY_DIRS@ ;
+
+@ZSTD_EXTERNAL@ @ZSTD_VERSION@
+             @ZSTD_STRING@
+
+@LZMA_EXTERNAL@ @LZMA_VERSION@
+             @LZMA_STRING@


### PR DESCRIPTION
When brew installs software to a directory other than /usr/local boost can't find the packages since they are not in the default search paths. This is the case on Apple silicon. Let CMake find the packages and pass the proper information to the boost build process.