### PR TITLE
fix URLs for HepMC tarball

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -273,7 +273,7 @@ ExternalProject_Add(pythia6
 list(APPEND packages hepmc)
 set(hepmc_version "2.06.11")
 ExternalProject_Add(hepmc
-  URL https://hepmc.web.cern.ch/hepmc/releases/hepmc${hepmc_version}.tgz
+  URL https://hepmc.web.cern.ch/releases/hepmc${hepmc_version}.tgz
   URL_HASH SHA256=86b66ea0278f803cde5774de8bd187dd42c870367f1cbf6cdaec8dc7cf6afc10
   ${CMAKE_DEFAULT_ARGS} CMAKE_ARGS
     "-Dlength:STRING=CM"

--- a/repos/fairsoft-backports/packages/hepmc/package.py
+++ b/repos/fairsoft-backports/packages/hepmc/package.py
@@ -8,8 +8,8 @@ class Hepmc(CMakePackage):
     """The HepMC package is an object oriented, C++ event record for
        High Energy Physics Monte Carlo generators and simulation."""
 
-    homepage = "https://hepmc.web.cern.ch/hepmc/"
-    url      = "https://hepmc.web.cern.ch/hepmc/releases/hepmc2.06.11.tgz"
+    homepage = "https://hepmc.web.cern.ch/"
+    url      = "https://hepmc.web.cern.ch/releases/hepmc2.06.11.tgz"
 
     tags = ['hep']
 
@@ -38,5 +38,5 @@ class Hepmc(CMakePackage):
         if version <= Version("2.06.08"):
             url = "http://lcgapp.cern.ch/project/simu/HepMC/download/HepMC-{0}.tar.gz"
         else:
-            url = "https://hepmc.web.cern.ch/hepmc/releases/hepmc{0}.tgz"
+            url = "https://hepmc.web.cern.ch/releases/hepmc{0}.tgz"
         return url.format(version)

--- a/test/test-start-container.sh
+++ b/test/test-start-container.sh
@@ -46,7 +46,7 @@ fi
 
 (
 	set -x
-	singularity exec -B"$bindmounts" "$image" bash -l -c "${ctestcmd}"
+	singularity exec --writable-tmpfs -B"$bindmounts" "$image" bash -l -c "${ctestcmd}"
 )
 retval=$?
 


### PR DESCRIPTION
following a server migration on hepmc.web.cern.ch, the URI no longer has the "/hepmc/" subdirectory (both for the homepage and the releases/ folder)