### PR TITLE
Build ROOTs Pythia8 interface

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -400,6 +400,7 @@ ExternalProject_Add(root
     "-Dmlp=ON"
     "-Dpyroot=ON"
     "-Dpythia6=ON"
+    "-Dpythia8=ON"
     "-Dreflex=OFF"
     "-Droofit=ON"
     "-Druntime_cxxmodules=OFF"


### PR DESCRIPTION
The default setting for the pythia8 interface was switched from ON to OFF
such that we have to switch it on explicitly.
