### PR TITLE
[legacy] build: Add `CI_BUILD_MODE` to reduce disk usage

### DIFF
--- a/FairSoftConfig.cmake
+++ b/FairSoftConfig.cmake
@@ -38,6 +38,23 @@ set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install" CACHE PATH "Install prefi
 # set(GEANT4MT ON CACHE BOOL "Build Geant4 in multi-threading mode" FORCE)
 
 #
+# CI Build Mode (default OFF)
+#
+#  Enable this to reduce peak disk usage during builds. When enabled:
+#  - Packages are built sequentially (one at a time) instead of in parallel
+#  - Each package's build and source directories are removed after installation
+#  - Disk usage is logged (space reclaimed + total build tree size)
+#
+#  The -j<ncpus> argument still parallelizes compilation within each package build.
+#  Trade-offs:
+#  - Builds take longer due to package serialization
+#  - Incremental rebuilds after failure are longer (removed packages must fully rebuild)
+#  Recommended for CI environments or systems with limited storage.
+#
+# set(CI_BUILD_MODE OFF CACHE BOOL "Serialize builds and remove package dirs after install" FORCE)
+# set(CI_BUILD_MODE ON CACHE BOOL "Serialize builds and remove package dirs after install" FORCE)
+
+#
 # Python
 #
 #  On macOS we assume you have used <source-dir>/legacy/setup-macos.sh which

--- a/cmake/reclaim-diskspace.cmake
+++ b/cmake/reclaim-diskspace.cmake
@@ -1,0 +1,64 @@
+# reclaim-diskspace.cmake
+# Remove package build/source directories after install to reclaim disk space
+# Expected variables: PACKAGE_NAME, PKG_BUILD_DIR, PKG_SOURCE_DIR, CMAKE_BINARY_DIR
+
+if(NOT DEFINED PACKAGE_NAME OR NOT DEFINED PKG_BUILD_DIR OR NOT DEFINED PKG_SOURCE_DIR)
+  message(FATAL_ERROR "PACKAGE_NAME, PKG_BUILD_DIR, and PKG_SOURCE_DIR must be defined")
+endif()
+
+# Helper function to measure directory size in MB
+function(measure_dir_size_mb dir out_var out_success)
+  set(${out_success} FALSE PARENT_SCOPE)
+  set(${out_var} 0 PARENT_SCOPE)
+  if(UNIX)
+    find_program(DU_EXECUTABLE du)
+    if(DU_EXECUTABLE)
+      execute_process(
+        COMMAND ${DU_EXECUTABLE} -sk "${dir}"
+        OUTPUT_VARIABLE du_output
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+      if(du_output)
+        string(REGEX REPLACE "^([0-9]+).*" "\\1" size_kb "${du_output}")
+        math(EXPR size_mb "${size_kb} / 1024")
+        set(${out_var} ${size_mb} PARENT_SCOPE)
+        set(${out_success} TRUE PARENT_SCOPE)
+      endif()
+    endif()
+  endif()
+endfunction()
+
+# Measure sizes before removal
+measure_dir_size_mb("${PKG_BUILD_DIR}" build_mb build_ok)
+measure_dir_size_mb("${PKG_SOURCE_DIR}" source_mb source_ok)
+
+if(build_ok AND source_ok)
+  math(EXPR total_mb "${build_mb} + ${source_mb}")
+  message(STATUS "[${PACKAGE_NAME}] Reclaiming ~${total_mb} MB (build: ${build_mb}, source: ${source_mb})")
+elseif(build_ok)
+  message(STATUS "[${PACKAGE_NAME}] Reclaiming ~${build_mb} MB")
+elseif(source_ok)
+  message(STATUS "[${PACKAGE_NAME}] Reclaiming ~${source_mb} MB")
+else()
+  message(STATUS "[${PACKAGE_NAME}] Removing package directories...")
+endif()
+
+# Remove package directories
+execute_process(COMMAND ${CMAKE_COMMAND} -E rm -rf "${PKG_BUILD_DIR}" RESULT_VARIABLE build_rm)
+execute_process(COMMAND ${CMAKE_COMMAND} -E rm -rf "${PKG_SOURCE_DIR}" RESULT_VARIABLE source_rm)
+
+if(NOT build_rm EQUAL 0)
+  message(WARNING "[${PACKAGE_NAME}] Failed to remove package build directory")
+endif()
+if(NOT source_rm EQUAL 0)
+  message(WARNING "[${PACKAGE_NAME}] Failed to remove package source directory")
+endif()
+
+# Report total build tree size
+if(DEFINED CMAKE_BINARY_DIR)
+  measure_dir_size_mb("${CMAKE_BINARY_DIR}" tree_mb tree_ok)
+  if(tree_ok)
+    message(STATUS "[${PACKAGE_NAME}] Build tree size: ${tree_mb} MB")
+  endif()
+endif()


### PR DESCRIPTION
Add `CI_BUILD_MODE` option to reduce peak disk usage during builds, addressing #576.

When enabled (`-DCI_BUILD_MODE=ON`):
- Packages are built sequentially instead of in parallel
- Each package's build and source directories are removed after installation
- Disk usage is logged after each step (space reclaimed + build tree size), example:
  ```
  [ 73%] Cleaning root package build/source directories
  -- [root] Reclaiming ~6533 MB (build: 5107, source: 1426)
  -- [root] Build tree size: 216 MB
  ```

Trade-offs:
- Slower builds due to serialization (but `-j<ncpus>` still parallelizes within each package)
- Incremental rebuilds after failure require full rebuild of removed packages

Recommended for CI environments or systems with limited storage.

Full example build log:
```
❯ cmake -S . -B build -C FairSoftConfig.cmake -DCI_BUILD_MODE=ON
loading initial cache file FairSoftConfig.cmake
-- The C compiler identification is GNU 15.2.1
-- The CXX compiler identification is GNU 15.2.1
-- The Fortran compiler identification is GNU 15.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: /usr/bin/gfortran - skipped
-- Looking for lzma_auto_decoder in /usr/lib64/liblzma.so
-- Looking for lzma_auto_decoder in /usr/lib64/liblzma.so - found
-- Looking for lzma_easy_encoder in /usr/lib64/liblzma.so
-- Looking for lzma_easy_encoder in /usr/lib64/liblzma.so - found
-- Looking for lzma_lzma_preset in /usr/lib64/liblzma.so
-- Looking for lzma_lzma_preset in /usr/lib64/liblzma.so - found
-- Found LibLZMA: /usr/lib64/liblzma.so (found version "5.8.1")
-- LZMA installation found. Boost iostream will be build with lzma compression
-- Found ZSTD: /usr/lib64/libzstd.so (found version "1.5.7")
-- ZSTD installation found. Boost iostream will be build with zstd compression
-- Found Git: /usr/bin/git (found version "2.51.1")
-- Found Patch: /usr/bin/patch
-- Found UnixCommands: /usr/bin/bash
-- NCPUS: 16 (from ProcessorCount())
-- Found Python: /usr/bin/python3.14 (found suitable version "3.14.0", minimum required is "3") found components: Interpreter Development Development.Module Development.Embed
--   
--   CXX STANDARD       C++17 (change with -DCMAKE_CXX_STANDARD=17)
--   
--   BUILD TYPE         RelWithDebInfo (change with -DCMAKE_BUILD_TYPE=...)
--   
--   PACKAGE              VERSION         OPTION
--   boost                1.87.0          
--   clhep                2.4.7.1         
--   dds                  3.13            optional (by building target dds explicitely)
--   faircmakemodules     1.0.0           
--   fairlogger           2.2.0           
--   fairmq               1.9.2           
--   flatbuffers          23.5.26         
--   fmt                  11.1.4          
--   geant3               4-4_fairsoft    
--   geant4               11.3.2          single-threaded (change with -DGEANT4MT=ON)
--   geant4_vmc           6-7-p1          
--   hepmc                2.06.11         
--   onnxruntime          1.22.2          optional (by building target onnxruntime explicitely)
--   pythia8              8315            
--   root                 6.36.04         
--   vc                   1.4.4           
--   vecgeom              v2.0.0-rc.6     
--   vgm                  5-3-1           
--   vmc                  2-1             
--   zeromq               4.3.5           
--   
--   SOURCE CACHE       using upstream URLs (generate cache by building target 'source-cache' and pass via -DSOURCE_CACHE=...)
--   
--   CI_BUILD_MODE      ON (build directories cleaned after install to save space)
--   
--   INSTALL PREFIX     /home/dklein/projects/FairSoft/install (change with -DCMAKE_INSTALL_PREFIX=...)
--   
--    -> export SIMPATH=/home/dklein/projects/FairSoft/install
--   
-- Configuring done (1.2s)
-- Generating done (0.1s)
-- Build files have been written to: /home/dklein/projects/FairSoft/build
❯ cmake --build build -j16
[  1%] Creating directories for 'faircmakemodules'
[  1%] Performing download step (git clone) for 'faircmakemodules'
-- faircmakemodules download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/faircmakemodules-download-*.log
[  1%] Performing update step for 'faircmakemodules'
-- faircmakemodules update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/faircmakemodules-update-*.log
[  1%] No patch step for 'faircmakemodules'
[  2%] Performing configure step for 'faircmakemodules'
-- faircmakemodules configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/faircmakemodules-configure-*.log
[  2%] Performing build step for 'faircmakemodules'
-- faircmakemodules build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/faircmakemodules-build-*.log
[  2%] Performing install step for 'faircmakemodules'
-- faircmakemodules install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/faircmakemodules-install-*.log
[  4%] Cleaning faircmakemodules package build/source directories
-- [faircmakemodules] Reclaiming ~7 MB (build: 1, source: 6)
-- [faircmakemodules] Build tree size: 3 MB
[  5%] Completed 'faircmakemodules'
[  5%] Built target faircmakemodules
[  5%] Creating directories for 'boost'
[  5%] Performing download step (download, verify and extract) for 'boost'
-- boost download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/boost-download-*.log
[  5%] No update step for 'boost'
[  7%] No patch step for 'boost'
[  7%] Performing configure step for 'boost'
-- boost configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/boost-configure-*.log
[  8%] Performing build step for 'boost'
-- boost build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/boost-build-*.log
[ 10%] Performing install step for 'boost'
-- boost install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/boost-install-*.log
[ 10%] Cleaning boost package build/source directories
-- [boost] Reclaiming ~1001 MB (build: 0, source: 1001)
-- [boost] Build tree size: 135 MB
[ 10%] Completed 'boost'
[ 10%] Built target boost
[ 10%] Creating directories for 'fmt'
[ 11%] Performing download step (download, verify and extract) for 'fmt'
-- fmt download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fmt-download-*.log
[ 13%] No update step for 'fmt'
[ 14%] No patch step for 'fmt'
[ 14%] Performing configure step for 'fmt'
-- fmt configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fmt-configure-*.log
[ 15%] Performing build step for 'fmt'
-- fmt build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fmt-build-*.log
[ 15%] Performing install step for 'fmt'
-- fmt install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fmt-install-*.log
[ 15%] Cleaning fmt package build/source directories
-- [fmt] Reclaiming ~439 MB (build: 434, source: 5)
-- [fmt] Build tree size: 136 MB
[ 15%] Completed 'fmt'
[ 15%] Built target fmt
[ 15%] Creating directories for 'fairlogger'
[ 17%] Performing download step (git clone) for 'fairlogger'
-- fairlogger download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairlogger-download-*.log
[ 18%] Performing update step for 'fairlogger'
-- fairlogger update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairlogger-update-*.log
[ 20%] No patch step for 'fairlogger'
[ 20%] Performing configure step for 'fairlogger'
-- fairlogger configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairlogger-configure-*.log
[ 21%] Performing build step for 'fairlogger'
-- fairlogger build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairlogger-build-*.log
[ 21%] Performing install step for 'fairlogger'
-- fairlogger install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairlogger-install-*.log
[ 21%] Cleaning fairlogger package build/source directories
-- [fairlogger] Reclaiming ~50 MB (build: 49, source: 1)
-- [fairlogger] Build tree size: 136 MB
[ 21%] Completed 'fairlogger'
[ 21%] Built target fairlogger
[ 21%] Creating directories for 'zeromq'
[ 21%] Performing download step (git clone) for 'zeromq'
-- zeromq download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/zeromq-download-*.log
[ 23%] Performing update step for 'zeromq'
-- zeromq update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/zeromq-update-*.log
[ 24%] Performing patch step for 'zeromq'
-- zeromq patch command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/zeromq-patch-*.log
[ 24%] Performing configure step for 'zeromq'
-- zeromq configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/zeromq-configure-*.log
[ 26%] Performing build step for 'zeromq'
-- zeromq build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/zeromq-build-*.log
[ 27%] Performing install step for 'zeromq'
-- zeromq install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/zeromq-install-*.log
[ 27%] Cleaning zeromq package build/source directories
-- [zeromq] Reclaiming ~270 MB (build: 239, source: 31)
-- [zeromq] Build tree size: 136 MB
[ 27%] Completed 'zeromq'
[ 27%] Built target zeromq
[ 28%] Creating directories for 'flatbuffers'
[ 28%] Performing download step (git clone) for 'flatbuffers'
-- flatbuffers download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/flatbuffers-download-*.log
[ 28%] Performing update step for 'flatbuffers'
-- flatbuffers update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/flatbuffers-update-*.log
[ 28%] No patch step for 'flatbuffers'
[ 30%] Performing configure step for 'flatbuffers'
-- flatbuffers configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/flatbuffers-configure-*.log
[ 30%] Performing build step for 'flatbuffers'
-- flatbuffers build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/flatbuffers-build-*.log
[ 30%] Performing install step for 'flatbuffers'
-- flatbuffers install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/flatbuffers-install-*.log
[ 31%] Cleaning flatbuffers package build/source directories
-- [flatbuffers] Reclaiming ~282 MB (build: 241, source: 41)
-- [flatbuffers] Build tree size: 137 MB
[ 33%] Completed 'flatbuffers'
[ 33%] Built target flatbuffers
[ 33%] Creating directories for 'fairmq'
[ 33%] Performing download step (git clone) for 'fairmq'
-- fairmq download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairmq-download-*.log
[ 33%] Performing update step for 'fairmq'
-- fairmq update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairmq-update-*.log
[ 33%] No patch step for 'fairmq'
[ 34%] Performing configure step for 'fairmq'
-- fairmq configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairmq-configure-*.log
[ 34%] Performing build step for 'fairmq'
-- fairmq build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairmq-build-*.log
[ 36%] Performing install step for 'fairmq'
-- fairmq install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairmq-install-*.log
[ 37%] Cleaning fairmq package build/source directories
-- [fairmq] Reclaiming ~729 MB (build: 681, source: 48)
-- [fairmq] Build tree size: 137 MB
[ 37%] Completed 'fairmq'
[ 37%] Built target fairmq
[ 37%] Creating directories for 'hepmc'
[ 37%] Performing download step (download, verify and extract) for 'hepmc'
-- hepmc download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/hepmc-download-*.log
[ 37%] No update step for 'hepmc'
[ 37%] Performing patch step for 'hepmc'
-- hepmc patch command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/hepmc-patch-*.log
[ 39%] Performing configure step for 'hepmc'
-- hepmc configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/hepmc-configure-*.log
[ 39%] Performing build step for 'hepmc'
-- hepmc build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/hepmc-build-*.log
[ 40%] Performing install step for 'hepmc'
-- hepmc install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/hepmc-install-*.log
[ 42%] Cleaning hepmc package build/source directories
-- [hepmc] Reclaiming ~66 MB (build: 54, source: 12)
-- [hepmc] Build tree size: 141 MB
[ 42%] Completed 'hepmc'
[ 42%] Built target hepmc
[ 43%] Creating directories for 'vc'
[ 43%] Performing download step (download, verify and extract) for 'vc'
-- vc download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vc-download-*.log
[ 43%] No update step for 'vc'
[ 43%] Performing patch step for 'vc'
-- vc patch command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vc-patch-*.log
[ 44%] Performing configure step for 'vc'
-- vc configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vc-configure-*.log
[ 44%] Performing build step for 'vc'
-- vc build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vc-build-*.log
[ 44%] Performing install step for 'vc'
-- vc install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vc-install-*.log
[ 46%] Cleaning vc package build/source directories
-- [vc] Reclaiming ~26 MB (build: 22, source: 4)
-- [vc] Build tree size: 142 MB
[ 47%] Completed 'vc'
[ 47%] Built target vc
[ 49%] Creating directories for 'clhep'
[ 49%] Performing download step (download, verify and extract) for 'clhep'
-- clhep download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/clhep-download-*.log
[ 49%] No update step for 'clhep'
[ 49%] Performing move_dir step for 'clhep'
-- clhep move_dir command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/clhep-move_dir-*.log
[ 50%] Performing patch step for 'clhep'
-- clhep patch command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/clhep-patch-*.log
[ 52%] Performing configure step for 'clhep'
-- clhep configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/clhep-configure-*.log
[ 52%] Performing build step for 'clhep'
-- clhep build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/clhep-build-*.log
[ 52%] Performing install step for 'clhep'
-- clhep install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/clhep-install-*.log
[ 52%] Cleaning clhep package build/source directories
-- [clhep] Reclaiming ~501 MB (build: 488, source: 13)
-- [clhep] Build tree size: 143 MB
[ 53%] Completed 'clhep'
[ 53%] Built target clhep
[ 53%] Creating directories for 'pythia8'
[ 53%] Performing download step (download, verify and extract) for 'pythia8'
-- pythia8 download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/pythia8-download-*.log
[ 53%] No update step for 'pythia8'
[ 55%] No patch step for 'pythia8'
[ 55%] Performing configure step for 'pythia8'
-- pythia8 configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/pythia8-configure-*.log
[ 56%] Performing build step for 'pythia8'
-- pythia8 build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/pythia8-build-*.log
[ 57%] Performing install step for 'pythia8'
-- pythia8 install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/pythia8-install-*.log
[ 57%] Cleaning pythia8 package build/source directories
-- [pythia8] Reclaiming ~1594 MB (build: 0, source: 1594)
-- [pythia8] Build tree size: 173 MB
[ 57%] Completed 'pythia8'
[ 57%] Built target pythia8
[ 57%] Creating directories for 'vecgeom'
[ 59%] Performing download step (git clone) for 'vecgeom'
-- vecgeom download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vecgeom-download-*.log
[ 60%] Performing update step for 'vecgeom'
-- vecgeom update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vecgeom-update-*.log
[ 62%] No patch step for 'vecgeom'
[ 62%] Performing configure step for 'vecgeom'
-- vecgeom configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vecgeom-configure-*.log
[ 63%] Performing build step for 'vecgeom'
-- vecgeom build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vecgeom-build-*.log
[ 63%] Performing install step for 'vecgeom'
-- vecgeom install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vecgeom-install-*.log
[ 63%] Cleaning vecgeom package build/source directories
-- [vecgeom] Reclaiming ~503 MB (build: 437, source: 66)
-- [vecgeom] Build tree size: 173 MB
[ 63%] Completed 'vecgeom'
[ 63%] Built target vecgeom
[ 65%] Creating directories for 'geant4'
[ 66%] Performing download step (download, verify and extract) for 'geant4'
-- geant4 download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant4-download-*.log
[ 68%] No update step for 'geant4'
[ 68%] No patch step for 'geant4'
[ 68%] Performing configure step for 'geant4'
-- geant4 configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant4-configure-*.log
[ 68%] Performing build step for 'geant4'
-- geant4 build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant4-build-*.log
[ 68%] Performing install step for 'geant4'
-- geant4 install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant4-install-*.log
[ 68%] Cleaning geant4 package build/source directories
-- [geant4] Reclaiming ~6998 MB (build: 6803, source: 195)
-- [geant4] Build tree size: 215 MB
[ 69%] Completed 'geant4'
[ 69%] Built target geant4
[ 71%] Creating directories for 'root'
[ 71%] Performing download step (git clone) for 'root'
-- root download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/root-download-*.log
[ 71%] Performing disconnected update step for 'root'
-- root update_disconnected command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/root-update_disconnected-*.log
[ 71%] Performing patch_disconnected step for 'root'
-- root patch_disconnected command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/root-patch_disconnected-*.log
[ 72%] Performing configure step for 'root'
-- root configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/root-configure-*.log
[ 72%] Performing build step for 'root'
-- root build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/root-build-*.log
[ 72%] Performing install step for 'root'
-- root install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/root-install-*.log
[ 73%] Cleaning root package build/source directories
-- [root] Reclaiming ~6533 MB (build: 5107, source: 1426)
-- [root] Build tree size: 216 MB
[ 75%] Completed 'root'
[ 75%] Built target root
[ 78%] Creating directories for 'vmc'
[ 78%] Creating directories for 'fairsoft-config'
[ 79%] Performing download step (git clone) for 'vmc'
[ 81%] Performing download step (git clone) for 'fairsoft-config'
-- fairsoft-config download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairsoft-config-download-*.log
[ 81%] Performing update step for 'fairsoft-config'
-- vmc download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vmc-download-*.log
[ 82%] Performing update step for 'vmc'
-- vmc update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vmc-update-*.log
[ 82%] No patch step for 'vmc'
[ 82%] Performing configure step for 'vmc'
-- fairsoft-config update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairsoft-config-update-*.log
[ 82%] No patch step for 'fairsoft-config'
[ 82%] Performing configure step for 'fairsoft-config'
-- vmc configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vmc-configure-*.log
[ 82%] Performing build step for 'vmc'
-- fairsoft-config configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairsoft-config-configure-*.log
[ 82%] Performing build step for 'fairsoft-config'
-- fairsoft-config build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairsoft-config-build-*.log
[ 82%] Performing install step for 'fairsoft-config'
-- fairsoft-config install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/fairsoft-config-install-*.log
[ 84%] Completed 'fairsoft-config'
[ 84%] Built target fairsoft-config
-- vmc build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vmc-build-*.log
[ 84%] Performing install step for 'vmc'
-- vmc install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vmc-install-*.log
[ 84%] Cleaning vmc package build/source directories
-- [vmc] Reclaiming ~8 MB (build: 7, source: 1)
-- [vmc] Build tree size: 217 MB
[ 85%] Completed 'vmc'
[ 85%] Built target vmc
[ 85%] Creating directories for 'geant3'
[ 85%] Performing download step (git clone) for 'geant3'
-- geant3 download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant3-download-*.log
[ 85%] Performing update step for 'geant3'
-- geant3 update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant3-update-*.log
[ 85%] Performing patch step for 'geant3'
-- geant3 patch command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant3-patch-*.log
[ 86%] Performing configure step for 'geant3'
-- geant3 configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant3-configure-*.log
[ 86%] Performing build step for 'geant3'
-- geant3 build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant3-build-*.log
[ 88%] Performing install step for 'geant3'
-- geant3 install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant3-install-*.log
[ 89%] Cleaning geant3 package build/source directories
-- [geant3] Reclaiming ~144 MB (build: 43, source: 101)
-- [geant3] Build tree size: 217 MB
[ 89%] Completed 'geant3'
[ 89%] Built target geant3
[ 89%] Creating directories for 'vgm'
[ 89%] Performing download step (git clone) for 'vgm'
-- vgm download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vgm-download-*.log
[ 89%] Performing update step for 'vgm'
-- vgm update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vgm-update-*.log
[ 89%] No patch step for 'vgm'
[ 91%] Performing configure step for 'vgm'
-- vgm configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vgm-configure-*.log
[ 91%] Performing build step for 'vgm'
-- vgm build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vgm-build-*.log
[ 92%] Performing install step for 'vgm'
-- vgm install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/vgm-install-*.log
[ 94%] Cleaning vgm package build/source directories
-- [vgm] Reclaiming ~167 MB (build: 98, source: 69)
-- [vgm] Build tree size: 217 MB
[ 94%] Completed 'vgm'
[ 94%] Built target vgm
[ 94%] Creating directories for 'geant4_vmc'
[ 94%] Performing download step (git clone) for 'geant4_vmc'
-- geant4_vmc download command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant4_vmc-download-*.log
[ 95%] Performing update step for 'geant4_vmc'
-- geant4_vmc update command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant4_vmc-update-*.log
[ 97%] No patch step for 'geant4_vmc'
[ 97%] Performing configure step for 'geant4_vmc'
-- geant4_vmc configure command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant4_vmc-configure-*.log
[ 98%] Performing build step for 'geant4_vmc'
-- geant4_vmc build command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant4_vmc-build-*.log
[100%] Performing install step for 'geant4_vmc'
-- geant4_vmc install command succeeded.  See also /home/dklein/projects/FairSoft/build/Log/geant4_vmc-install-*.log
[100%] Cleaning geant4_vmc package build/source directories
-- [geant4_vmc] Reclaiming ~242 MB (build: 173, source: 69)
-- [geant4_vmc] Build tree size: 217 MB
[100%] Completed 'geant4_vmc'
[100%] Built target geant4_vmc
```