### PR TITLE
Fix boost source

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -163,7 +163,7 @@ if("${isSystemDir}" STREQUAL "-1")
 endif()
 
 ExternalProject_Add(boost
-  URL "https://boostorg.jfrog.io/artifactory/main/release/1.${boost_version}.0/source/boost_1_${boost_version}_0.tar.bz2"
+  URL "https://archives.boost.io/release/1.${boost_version}.0/source/boost_1_${boost_version}_0.tar.bz2"
   URL_HASH SHA256=6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e
   BUILD_IN_SOURCE ON
   PATCH_COMMAND ${patch} -d libs/python -p1 -i "${CMAKE_SOURCE_DIR}/legacy/boost/support-numpy-2.patch"


### PR DESCRIPTION
When building FairSoft, I have following error:
```
-- SHA256 hash of
    /home/rafal/cbm/software/src/FairSoft/build/Download/boost/boost_1_83_0.tar.bz2
  does not match expected value
    expected: '6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e'
      actual: '1c162b579a423fa6876c6c5bc16d39ab4bc05e28898977a0a6af345f523f6357'
```

And apparently the source file: https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2
is not valid boost code.

I don't know what jfrog.io is, but we should not download code from anything else than original source.