### PR TITLE
Fix build on macosx26

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -355,7 +355,7 @@ set(pythia8_version "8317")
 string(SUBSTRING "${pythia8_version}" 0 2 pythia8_major_version)
 string(TOUPPER "${CMAKE_BUILD_TYPE}" selected)
 ExternalProject_Add(pythia8
-  URL https://pythia.org/download/pythia${pythia8_major_version}/pythia${pythia8_version}.tgz
+  URL https://pythia.org/releases/pythia${pythia8_major_version}/pythia${pythia8_version}.tgz
   URL_HASH SHA256=1ae551d14dac495ddfe6b344792035ebe410fe6c6004d44a335e0ece0e745adf
   BUILD_IN_SOURCE ON
   CONFIGURE_COMMAND ${CMAKE_BINARY_DIR}/Source/pythia8/configure

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -483,6 +483,7 @@ ExternalProject_Add(root
   PATCH_COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/root/fix_macos_sdk_mismatch.patch"
   COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/root/fix_macos_sdk_for_rootcling.patch"
   COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/root/fix_rpath_info.patch"
+  COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/root/backports_macos_sdk_26_4_from_root.patch"
   DEPENDS pythia8 vc vecgeom ${extract_source_cache_target}
   ${LOG_TO_FILE}
 )

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -563,7 +563,7 @@ ExternalProject_Add(onnxruntime
 ExternalProject_Add(fairsoft-config
   GIT_REPOSITORY https://github.com/FairRootGroup/fairsoft-config GIT_TAG master
   ${CMAKE_DEFAULT_ARGS} CMAKE_ARGS
-  "-DFAIRSOFT_VERSION=feb26p1"
+  "-DFAIRSOFT_VERSION=feb26p2"
   DEPENDS root ${extract_source_cache_target}
   ${LOG_TO_FILE}
 )

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -484,6 +484,7 @@ ExternalProject_Add(root
   COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/root/fix_macos_sdk_for_rootcling.patch"
   COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/root/fix_rpath_info.patch"
   COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/root/backports_macos_sdk_26_4_from_root.patch"
+  COMMAND ${patch} -p1 -i "${CMAKE_SOURCE_DIR}/legacy/root/fix_cmake_44.patch"
   DEPENDS pythia8 vc vecgeom ${extract_source_cache_target}
   ${LOG_TO_FILE}
 )

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -118,23 +118,24 @@ The following systems are tested regularly. If you feel your system is missing,
 please contact us.
 
 | **OS Name** | **Arch** | **OS Version** | **Compiler** | **CMake** |
-| --- | --- | --- | --- | --- |
-| Debian     | x86_64 | 12    | GCC 12.2.0                             | 3.25.1 |
-| Debian     | x86_64 | 12    | GCC 12.2.0                             | 4.2.3 (bootstrap) |
-| Debian     | x86_64 | 13    | GCC 14.2.0                             | 3.31.6 |
-| Fedora     | x86_64 | 38    | GCC 13.2.1                             | 3.27.7 |
-| Fedora     | x86_64 | 38    | GCC 13.2.1                             | 4.2.3 (bootstrap) |
-| Fedora     | x86_64 | 40    | GCC 14.2.1                             | 3.30.8 |
-| Fedora     | x86_64 | 42    | GCC 15.2.1                             | 3.31.6 |
-| Fedora     | x86_64 | 43    | GCC 15.2.1                             | 3.31.10 |
-| macOS      | x86_64 | 15    | SDK 26, AppleClang 17, gfortran 15.2.0 | 4.2.0 (brew) |
-| macOS      | arm64  | 26    | SDK 26, AppleClang 17, gfortran 15.2.0 | 4.2.3 (brew) |
-| macOS      | arm64  | 26    | SDK 14, AppleClang 17, gfortran 15.2.0 | 4.2.3 (brew) |
-| OpenSuse   | x86_64 | 15.6  | GCC 14.3.0 (non system)                | 3.28.3 |
-| OpenSuse   | x86_64 | 16.0  | GCC 15.1.1                             | 3.31.7 |
-| Ubuntu     | x86_64 | 22.04 | GCC 11.4.0                             | 4.2.3 (bootstrap) |
-| Ubuntu     | x86_64 | 24.04 | GCC 13.3.0                             | 3.28.3 |
-| Ubuntu     | x86_64 | 26.04 | GCC 15.2.0                             | 3.31.6 |
+| --- | --- | --- | --- | ---   |
+| Debian     | x86_64 | 12      | GCC 12.2.0                               | 4.2.3 (bootstrap) |
+| Debian     | x86_64 | 13      | GCC 14.2.0                               | 3.31.6 |
+| Fedora     | x86_64 | 38      | GCC 13.2.1                               | 3.27.7 |
+| Fedora     | x86_64 | 38      | GCC 13.2.1                               | 4.2.3 (bootstrap) |
+| Fedora     | x86_64 | 40      | GCC 14.2.1                               | 3.30.8 |
+| Fedora     | x86_64 | 42      | GCC 15.2.1                               | 3.31.11 |
+| Fedora     | x86_64 | 43      | GCC 15.2.1                               | 3.31.11 |
+| macOS      | x86_64 | 15.7.7  | SDK 14.5, AppleClang 17, gfortran 16.1.0 | 4.3.4 (brew) |
+| macOS      | x86_64 | 15.7.7  | SDK 26.2, AppleClang 17, gfortran 16.1.0 | 4.3.4 (brew) |
+| macOS      | arm64  | 26.5.2  | SDK 26.5, AppleClang 21, gfortran 16.1.0 | 4.4.0 (brew) |
+| macOS      | arm64  | 26.5.2  | SDK 14.5, AppleClang 21, gfortran 16.1.0 | 4.4.0 (brew) |
+| macOS      | arm64  | 27beta2 | SDK 26.5, AppleClang 21, gfortran 16.1.0 | 4.4.0 (brew) |
+| OpenSuse   | x86_64 | 15.6    | GCC 14.3.0 (non system)                  | 3.28.3 |
+| OpenSuse   | x86_64 | 16.0    | GCC 15.3.0                               | 3.31.7 |
+| Ubuntu     | x86_64 | 22.04   | GCC 11.4.0                               | 4.2.3 (bootstrap) |
+| Ubuntu     | x86_64 | 24.04   | GCC 13.3.0                               | 3.28.3 |
+| Ubuntu     | x86_64 | 26.04   | GCC 15.2.0                               | 3.31.6 |
 
 ## Included packages
 

--- a/legacy/root/backports_macos_sdk_26_4_from_root.patch
+++ b/legacy/root/backports_macos_sdk_26_4_from_root.patch
@@ -1,0 +1,379 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e8060c7d1d6..185686d479b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,6 +13,11 @@ if(WIN32)
+   set(CMAKE_SKIP_TEST_ALL_DEPENDENCY TRUE)
+ endif()
+ 
++if(CMAKE_HOST_APPLE)
++  # Don't move this because the SDK needs to be set before "project(ROOT)"
++  include(cmake/modules/SetOSX_SDK.cmake)
++endif()
++
+ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND NOT ALLOW_IN_SOURCE)
+   message(FATAL_ERROR
+     " ROOT must be built out-of-source.\n"
+diff --git a/cmake/modules/SetOSX_SDK.cmake b/cmake/modules/SetOSX_SDK.cmake
+new file mode 100644
+index 00000000000..cceb8ae0f3d
+--- /dev/null
++++ b/cmake/modules/SetOSX_SDK.cmake
+@@ -0,0 +1,40 @@
++# The SDKROOT environment variable and/or CMAKE_OSX_SYSROOT CMake variable need to be set *before* any project(ROOT) call.
++# This is necessary to find (and for cling to remember) the SDK, so don't remove this unless tested with all combinations of
++# incremental builds, fresh builds, having SDKROOT set, having CMAKE_OSX_SYSROOT set, and also not having them set.
++# The CMake 4 standard of leaving it to the compiler to figure out the SDK doesn't work for Cling.
++# See https://github.com/root-project/root/pull/19718, https://github.com/root-project/root/pull/19855 for failed attempts to remove this.
++
++# To choose an SDK, one has the following options:
++# - Let xcrun choose the latest installed SDK: "cmake ..."
++# - Configure an SDK using "SDKROOT=<path> cmake ..."
++# - Set a cache variable: "cmake -DCMAKE_OSX_SYSROOT=<path> ..."
++
++if(NOT IS_DIRECTORY "${CMAKE_OSX_SYSROOT}")
++  unset(CMAKE_OSX_SYSROOT CACHE)
++  unset(CMAKE_OSX_SYSROOT)
++endif()
++
++find_program(XCRUN_EXECUTABLE xcrun)
++if(EXISTS ${XCRUN_EXECUTABLE})
++  if(NOT DEFINED CMAKE_OSX_SYSROOT)
++    execute_process(COMMAND ${XCRUN_EXECUTABLE} --sdk macosx --show-sdk-path
++      OUTPUT_VARIABLE SDK_PATH
++      OUTPUT_STRIP_TRAILING_WHITESPACE)
++    if(NOT IS_DIRECTORY "${SDK_PATH}")
++      message(FATAL_ERROR "Could not detect macOS SDK path")
++    endif()
++    set(CMAKE_OSX_SYSROOT "${SDK_PATH}" CACHE PATH "MacOS SDK path" FORCE)
++  endif()
++
++  # Save the SDK version for ROOT to inspect it later. This is needed for LTS that live longer
++  # then the SDK they were created with.
++  execute_process(COMMAND ${XCRUN_EXECUTABLE} --sdk ${CMAKE_OSX_SYSROOT} --show-sdk-version
++    OUTPUT_VARIABLE OSX_SDK_VERSION
++    OUTPUT_STRIP_TRAILING_WHITESPACE)
++  mark_as_advanced(OSX_SDK_VERSION)
++endif()
++
++if(NOT IS_DIRECTORY "${CMAKE_OSX_SYSROOT}")
++  message(FATAL_ERROR "ROOT needs a path to an SDK to compile on Mac. Try setting CMAKE_OSX_SYSROOT or provide the xcrun executable.")
++endif()
++message(STATUS "Mac OS SDK version: '${OSX_SDK_VERSION}' ${CMAKE_OSX_SYSROOT}")
+diff --git a/interpreter/CMakeLists.txt b/interpreter/CMakeLists.txt
+index 322976bd1d2..cb17fb94983 100644
+--- a/interpreter/CMakeLists.txt
++++ b/interpreter/CMakeLists.txt
+@@ -10,6 +10,10 @@ if (NOT builtin_clang)
+   message(WARNING "Due to ROOT-specific patches you need a special version of clang. You cannot use vanilla clang.")
+ endif()
+ 
++if(APPLE AND builtin_clang AND OSX_SDK_VERSION VERSION_GREATER_EQUAL "26.4")
++  add_compile_definitions(MAC_SDK_WORKAROUND)
++endif()
++
+ #--Set the LLVM version required for ROOT-----------------------------------------------------------
+ set(ROOT_LLVM_VERSION_REQUIRED_MAJOR 18)
+ 
+diff --git a/interpreter/llvm-project/clang/include/clang/Basic/Builtins.def b/interpreter/llvm-project/clang/include/clang/Basic/Builtins.def
+index 4dcbaf8a7be..b7cc90d92e6 100644
+--- a/interpreter/llvm-project/clang/include/clang/Basic/Builtins.def
++++ b/interpreter/llvm-project/clang/include/clang/Basic/Builtins.def
+@@ -515,12 +515,16 @@ BUILTIN(__builtin_clzs , "iUs"  , "ncE")
+ BUILTIN(__builtin_clz  , "iUi"  , "ncE")
+ BUILTIN(__builtin_clzl , "iULi" , "ncE")
+ BUILTIN(__builtin_clzll, "iULLi", "ncE")
+-// TODO: int clzimax(uintmax_t)
++#if defined(MAC_SDK_WORKAROUND)
++BUILTIN(__builtin_clzg , "i."   , "nct")
++#endif
+ BUILTIN(__builtin_ctzs , "iUs"  , "ncE")
+ BUILTIN(__builtin_ctz  , "iUi"  , "ncE")
+ BUILTIN(__builtin_ctzl , "iULi" , "ncE")
+ BUILTIN(__builtin_ctzll, "iULLi", "ncE")
+-// TODO: int ctzimax(uintmax_t)
++#if defined(MAC_SDK_WORKAROUND)
++BUILTIN(__builtin_ctzg , "i."   , "nct")
++#endif
+ BUILTIN(__builtin_ffs  , "ii"  , "FncE")
+ BUILTIN(__builtin_ffsl , "iLi" , "FncE")
+ BUILTIN(__builtin_ffsll, "iLLi", "FncE")
+@@ -530,6 +534,9 @@ BUILTIN(__builtin_parityll, "iULLi", "ncE")
+ BUILTIN(__builtin_popcount  , "iUi"  , "ncE")
+ BUILTIN(__builtin_popcountl , "iULi" , "ncE")
+ BUILTIN(__builtin_popcountll, "iULLi", "ncE")
++#if defined(MAC_SDK_WORKAROUND)
++BUILTIN(__builtin_popcountg , "i."   , "ncE")
++#endif
+ BUILTIN(__builtin_clrsb  , "ii"  , "ncE")
+ BUILTIN(__builtin_clrsbl , "iLi" , "ncE")
+ BUILTIN(__builtin_clrsbll, "iLLi", "ncE")
+diff --git a/interpreter/llvm-project/clang/include/clang/Basic/TokenKinds.def b/interpreter/llvm-project/clang/include/clang/Basic/TokenKinds.def
+index c10e2adfbe6..cb6ddedffbb 100644
+--- a/interpreter/llvm-project/clang/include/clang/Basic/TokenKinds.def
++++ b/interpreter/llvm-project/clang/include/clang/Basic/TokenKinds.def
+@@ -567,6 +567,9 @@ TYPE_TRAIT_1(__is_unsigned, IsUnsigned, KEYCXX)
+ // Embarcadero Binary Type Traits
+ TYPE_TRAIT_2(__is_same, IsSame, KEYCXX)
+ TYPE_TRAIT_2(__is_convertible, IsConvertible, KEYCXX)
++#if defined(MAC_SDK_WORKAROUND)
++TYPE_TRAIT_2(__is_nothrow_convertible, IsNothrowConvertible, KEYCXX)
++#endif
+ ARRAY_TYPE_TRAIT(__array_rank, ArrayRank, KEYCXX)
+ ARRAY_TYPE_TRAIT(__array_extent, ArrayExtent, KEYCXX)
+ // Name for GCC 6 compatibility.
+diff --git a/interpreter/llvm-project/clang/lib/AST/ExprConstant.cpp b/interpreter/llvm-project/clang/lib/AST/ExprConstant.cpp
+index edf9b5e2d52..864eb14708f 100644
+--- a/interpreter/llvm-project/clang/lib/AST/ExprConstant.cpp
++++ b/interpreter/llvm-project/clang/lib/AST/ExprConstant.cpp
+@@ -12461,6 +12461,9 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
+   case Builtin::BI__builtin_popcount:
+   case Builtin::BI__builtin_popcountl:
+   case Builtin::BI__builtin_popcountll:
++#if defined(MAC_SDK_WORKAROUND)
++  case Builtin::BI__builtin_popcountg:
++#endif
+   case Builtin::BI__popcnt16: // Microsoft variants of popcount
+   case Builtin::BI__popcnt:
+   case Builtin::BI__popcnt64: {
+diff --git a/interpreter/llvm-project/clang/lib/CodeGen/CGBuiltin.cpp b/interpreter/llvm-project/clang/lib/CodeGen/CGBuiltin.cpp
+index 44ddd2428b1..3a136faea21 100644
+--- a/interpreter/llvm-project/clang/lib/CodeGen/CGBuiltin.cpp
++++ b/interpreter/llvm-project/clang/lib/CodeGen/CGBuiltin.cpp
+@@ -3130,36 +3130,92 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
+   case Builtin::BI__builtin_ctzs:
+   case Builtin::BI__builtin_ctz:
+   case Builtin::BI__builtin_ctzl:
++#if defined(MAC_SDK_WORKAROUND)
++  case Builtin::BI__builtin_ctzll:
++  case Builtin::BI__builtin_ctzg: {
++    bool HasFallback = BuiltinIDIfNoAsmLabel == Builtin::BI__builtin_ctzg &&
++                       E->getNumArgs() > 1;
++
++    Value *ArgValue =
++        HasFallback ? EmitScalarExpr(E->getArg(0))
++                    : EmitCheckedArgForBuiltin(E->getArg(0), BCK_CTZPassedZero);
++#else
+   case Builtin::BI__builtin_ctzll: {
+     Value *ArgValue = EmitCheckedArgForBuiltin(E->getArg(0), BCK_CTZPassedZero);
+ 
++#endif
+     llvm::Type *ArgType = ArgValue->getType();
+     Function *F = CGM.getIntrinsic(Intrinsic::cttz, ArgType);
+ 
+     llvm::Type *ResultType = ConvertType(E->getType());
++#if defined(MAC_SDK_WORKAROUND)
++    Value *ZeroUndef =
++        Builder.getInt1(HasFallback || getTarget().isCLZForZeroUndef());
++#else
+     Value *ZeroUndef = Builder.getInt1(getTarget().isCLZForZeroUndef());
++#endif
+     Value *Result = Builder.CreateCall(F, {ArgValue, ZeroUndef});
+     if (Result->getType() != ResultType)
+       Result = Builder.CreateIntCast(Result, ResultType, /*isSigned*/true,
+                                      "cast");
++#if defined(MAC_SDK_WORKAROUND)
++    if (!HasFallback)
++      return RValue::get(Result);
++
++    Value *Zero = Constant::getNullValue(ArgType);
++    Value *IsZero = Builder.CreateICmpEQ(ArgValue, Zero, "iszero");
++    Value *FallbackValue = EmitScalarExpr(E->getArg(1));
++    Value *ResultOrFallback =
++        Builder.CreateSelect(IsZero, FallbackValue, Result, "ctzg");
++    return RValue::get(ResultOrFallback);
++#else
+     return RValue::get(Result);
++#endif
+   }
+   case Builtin::BI__builtin_clzs:
+   case Builtin::BI__builtin_clz:
+   case Builtin::BI__builtin_clzl:
++#if defined(MAC_SDK_WORKAROUND)
++  case Builtin::BI__builtin_clzll:
++  case Builtin::BI__builtin_clzg: {
++    bool HasFallback = BuiltinIDIfNoAsmLabel == Builtin::BI__builtin_clzg &&
++                       E->getNumArgs() > 1;
++
++    Value *ArgValue =
++        HasFallback ? EmitScalarExpr(E->getArg(0))
++                    : EmitCheckedArgForBuiltin(E->getArg(0), BCK_CLZPassedZero);
++#else
+   case Builtin::BI__builtin_clzll: {
+     Value *ArgValue = EmitCheckedArgForBuiltin(E->getArg(0), BCK_CLZPassedZero);
+ 
++#endif
+     llvm::Type *ArgType = ArgValue->getType();
+     Function *F = CGM.getIntrinsic(Intrinsic::ctlz, ArgType);
+ 
+     llvm::Type *ResultType = ConvertType(E->getType());
++#if defined(MAC_SDK_WORKAROUND)
++    Value *ZeroUndef =
++        Builder.getInt1(HasFallback || getTarget().isCLZForZeroUndef());
++#else
+     Value *ZeroUndef = Builder.getInt1(getTarget().isCLZForZeroUndef());
++#endif
+     Value *Result = Builder.CreateCall(F, {ArgValue, ZeroUndef});
+     if (Result->getType() != ResultType)
+       Result = Builder.CreateIntCast(Result, ResultType, /*isSigned*/true,
+                                      "cast");
++#if defined(MAC_SDK_WORKAROUND)
++    if (!HasFallback)
++      return RValue::get(Result);
++
++    Value *Zero = Constant::getNullValue(ArgType);
++    Value *IsZero = Builder.CreateICmpEQ(ArgValue, Zero, "iszero");
++    Value *FallbackValue = EmitScalarExpr(E->getArg(1));
++    Value *ResultOrFallback =
++        Builder.CreateSelect(IsZero, FallbackValue, Result, "clzg");
++    return RValue::get(ResultOrFallback);
++#else
+     return RValue::get(Result);
++#endif
+   }
+   case Builtin::BI__builtin_ffs:
+   case Builtin::BI__builtin_ffsl:
+@@ -3219,7 +3275,12 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
+   case Builtin::BI__popcnt64:
+   case Builtin::BI__builtin_popcount:
+   case Builtin::BI__builtin_popcountl:
++#if defined(MAC_SDK_WORKAROUND)
++  case Builtin::BI__builtin_popcountll:
++  case Builtin::BI__builtin_popcountg: {
++#else
+   case Builtin::BI__builtin_popcountll: {
++#endif
+     Value *ArgValue = EmitScalarExpr(E->getArg(0));
+ 
+     llvm::Type *ArgType = ArgValue->getType();
+diff --git a/interpreter/llvm-project/clang/lib/Sema/SemaChecking.cpp b/interpreter/llvm-project/clang/lib/Sema/SemaChecking.cpp
+index 09b7e1c62fb..a73483114cb 100644
+--- a/interpreter/llvm-project/clang/lib/Sema/SemaChecking.cpp
++++ b/interpreter/llvm-project/clang/lib/Sema/SemaChecking.cpp
+@@ -2143,6 +2143,69 @@ static bool checkFPMathBuiltinElementType(Sema &S, SourceLocation Loc,
+   return false;
+ }
+ 
++#if defined(MAC_SDK_WORKAROUND)
++/// Checks that __builtin_popcountg was called with a single argument, which is
++/// an integer.
++static bool SemaBuiltinPopcountg(Sema &S, CallExpr *TheCall) {
++  if (checkArgCount(S, TheCall, 1))
++    return true;
++
++  Expr *Arg = TheCall->getArg(0);
++  QualType ArgTy = Arg->getType();
++
++  if (!ArgTy->isIntegerType()) {
++    S.Diag(Arg->getBeginLoc(), diag::err_builtin_invalid_arg_type)
++        << 1 << /*integer ty*/ 7 << ArgTy;
++    return true;
++  }
++  return false;
++}
++#endif
++
++#if defined(MAC_SDK_WORKAROUND)
++/// Checks that __builtin_{clzg,ctzg} was called with a first argument, which is
++/// an unsigned integer, and an optional second argument, which is promoted to
++/// an 'int'.
++static bool SemaBuiltinCountZeroBitsGeneric(Sema &S, CallExpr *TheCall) {
++  if (checkArgCountRange(S, TheCall, 1, 2))
++    return true;
++
++  ExprResult Arg0Res = S.DefaultLvalueConversion(TheCall->getArg(0));
++  if (Arg0Res.isInvalid())
++    return true;
++
++  Expr *Arg0 = Arg0Res.get();
++  TheCall->setArg(0, Arg0);
++
++  QualType Arg0Ty = Arg0->getType();
++
++  if (!Arg0Ty->isUnsignedIntegerType()) {
++    S.Diag(Arg0->getBeginLoc(), diag::err_builtin_invalid_arg_type)
++        << 1 << /*unsigned integer ty*/ 7 << Arg0Ty;
++    return true;
++  }
++
++  if (TheCall->getNumArgs() > 1) {
++    ExprResult Arg1Res = S.UsualUnaryConversions(TheCall->getArg(1));
++    if (Arg1Res.isInvalid())
++      return true;
++
++    Expr *Arg1 = Arg1Res.get();
++    TheCall->setArg(1, Arg1);
++
++    QualType Arg1Ty = Arg1->getType();
++
++    if (!Arg1Ty->isSpecificBuiltinType(BuiltinType::Int)) {
++      S.Diag(Arg1->getBeginLoc(), diag::err_builtin_invalid_arg_type)
++          << 2 << /*'int' ty*/ 8 << Arg1Ty;
++      return true;
++    }
++  }
++
++  return false;
++}
++#endif
++
+ ExprResult
+ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
+                                CallExpr *TheCall) {
+@@ -2900,7 +2963,21 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
+            diag::err_hip_invalid_args_builtin_mangled_name);
+       return ExprError();
+     }
++    break;
+   }
++#if defined(MAC_SDK_WORKAROUND)
++  case Builtin::BI__builtin_popcountg:
++    if (SemaBuiltinPopcountg(*this, TheCall))
++      return ExprError();
++    break;
++#endif
++#if defined(MAC_SDK_WORKAROUND)
++  case Builtin::BI__builtin_clzg:
++  case Builtin::BI__builtin_ctzg:
++    if (SemaBuiltinCountZeroBitsGeneric(*this, TheCall))
++      return ExprError();
++    break;
++#endif
+   }
+ 
+   // Since the target specific builtins for each arch overlap, only check those
+diff --git a/interpreter/llvm-project/clang/lib/Sema/SemaExprCXX.cpp b/interpreter/llvm-project/clang/lib/Sema/SemaExprCXX.cpp
+index c94b1e10950..eca41343869 100644
+--- a/interpreter/llvm-project/clang/lib/Sema/SemaExprCXX.cpp
++++ b/interpreter/llvm-project/clang/lib/Sema/SemaExprCXX.cpp
+@@ -5780,7 +5780,12 @@ static bool EvaluateBinaryTypeTrait(Sema &Self, TypeTrait BTT, QualType LhsT,
+     return Self.Context.typesAreCompatible(Lhs, Rhs);
+   }
+   case BTT_IsConvertible:
++#if defined(MAC_SDK_WORKAROUND)
++  case BTT_IsConvertibleTo:
++  case BTT_IsNothrowConvertible: {
++#else
+   case BTT_IsConvertibleTo: {
++#endif
+     // C++0x [meta.rel]p4:
+     //   Given the following function prototype:
+     //
+@@ -5841,7 +5846,17 @@ static bool EvaluateBinaryTypeTrait(Sema &Self, TypeTrait BTT, QualType LhsT,
+       return false;
+ 
+     ExprResult Result = Init.Perform(Self, To, Kind, FromPtr);
++#if defined(MAC_SDK_WORKAROUND)
++    if (Result.isInvalid() || SFINAE.hasErrorOccurred())
++      return false;
++
++    if (BTT != BTT_IsNothrowConvertible)
++      return true;
++
++    return Self.canThrow(Result.get()) == CT_Cannot;
++#else
+     return !Result.isInvalid() && !SFINAE.hasErrorOccurred();
++#endif
+   }
+ 
+   case BTT_IsAssignable:

--- a/legacy/root/fix_cmake_44.patch
+++ b/legacy/root/fix_cmake_44.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e8060c7d1d..f1074a3028 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -302,7 +307,7 @@ endif()
+ get_cmake_property(variables CACHE_VARIABLES)
+ foreach(var ${variables})
+   if((var MATCHES "_(LIBRARIES|LIBRARY|INCLUDE|VERSION)") AND
+-     (NOT ${${var}} STREQUAL "") AND
++     (NOT "${${var}}" STREQUAL "") AND
+      (NOT ${var} MATCHES "NOTFOUND"))
+     if (var MATCHES "^QT_")
+       # filter out the very long list of Qt libraries and include dirs


### PR DESCRIPTION
The PR fixes the following two problems:
- Use correct new download URL for Pythia8 which is needed for all supported platforms
- Backport fixes for ROOT such that Root v6.36.08 can be compiled with macos SDK 26.5 