### PR TITLE
Jan24: fix url for Pythia8 download (p6 -> p7)

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -591,7 +591,7 @@ ExternalProject_Add(onnxruntime
 ExternalProject_Add(fairsoft-config
   GIT_REPOSITORY https://github.com/FairRootGroup/fairsoft-config GIT_TAG master
   ${CMAKE_DEFAULT_ARGS} CMAKE_ARGS
-  "-DFAIRSOFT_VERSION=jan24p6"
+  "-DFAIRSOFT_VERSION=jan24p7"
   DEPENDS root ${extract_source_cache_target}
   ${LOG_TO_FILE}
 )

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -355,7 +355,7 @@ set(pythia8_version "8310")
 string(SUBSTRING "${pythia8_version}" 0 2 pythia8_major_version)
 string(TOUPPER "${CMAKE_BUILD_TYPE}" selected)
 ExternalProject_Add(pythia8
-  URL https://pythia.org/download/pythia${pythia8_major_version}/pythia${pythia8_version}.tgz
+  URL https://pythia.org/releases/pythia${pythia8_major_version}/pythia${pythia8_version}.tgz
   URL_HASH SHA256=90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227
   BUILD_IN_SOURCE ON
   CONFIGURE_COMMAND ${CMAKE_BINARY_DIR}/Source/pythia8/configure


### PR DESCRIPTION
Found while installing missing `jan24pX` + `v18.8.Y`  pair on `run4` in order to update the Cbmroot CI chain
- New main page for list of releases: https://pythia.org/releases.html
- From what I see in [current `master`](https://github.com/FairRootGroup/FairSoft/blame/2d5d5aaea5156594e10d3f8021b01f277f12c724/cmake/legacy.cmake#L358) and [current `dev`](https://github.com/FairRootGroup/FairSoft/blame/a5f0c30291b100601e70bf6ca6e681e9d1ae6601/cmake/legacy.cmake#L358) branches, probably needs to be also applied there and to `feb26`

Ping @fuhlig1 